### PR TITLE
Tweak time range label positions.

### DIFF
--- a/src/wtf/app/ui/nav/framebarpainter.js
+++ b/src/wtf/app/ui/nav/framebarpainter.js
@@ -122,7 +122,11 @@ wtf.app.ui.nav.FramebarPainter.prototype.repaintInternal = function(
             labelScreenWidth, labelWidth, labelWidth + 15 * 2, 0, 1);
         ctx.globalAlpha = alpha;
         ctx.fillStyle = '#FFFFFF';
-        var labelX = screenLeft + labelScreenWidth / 2 - labelWidth / 2;
+
+        // Attempt to center the text within the box, but clamp to the screen.
+        var labelX = lx + (rx - lx) / 2 - labelWidth / 2;
+        labelX = goog.math.clamp(labelX, 0, width - labelWidth);
+
         ctx.fillText(label, labelX, y + h - 4);
         ctx.globalAlpha = 1;
       }

--- a/src/wtf/app/ui/tracks/zonepainter.js
+++ b/src/wtf/app/ui/tracks/zonepainter.js
@@ -245,8 +245,10 @@ wtf.app.ui.tracks.ZonePainter.prototype.drawScopes_ = function(
         ctx.globalAlpha = alpha;
         ctx.fillStyle = '#FFFFFF';
 
-        // Draw label - clip to center of screen-visible region.
-        var x = screenLeft + labelScreenWidth / 2 - labelWidth / 2;
+        // Center the label within the box then clamp to the screen.
+        var x = left + (right - left) / 2 - labelWidth / 2;
+        x = goog.math.clamp(x, 0, width - labelWidth);
+
         var y = scopeTop + 12;
         ctx.fillText(label, x, y);
         ctx.globalAlpha = 1;


### PR DESCRIPTION
Instead of centering a label within the available (clipped to screen)
rectangle, we now always center withing the actual (full) time range,
and then clamp to the screen. The makes it a bit more clear that a box
is large and goes off screen, and also reduces excessive label
animations.
