### PR TITLE
Switch some hot goog.base calls to direct calls.

### DIFF
--- a/src/wtf/analysis/db/eventindex.js
+++ b/src/wtf/analysis/db/eventindex.js
@@ -51,6 +51,9 @@ wtf.analysis.db.EventIndex.prototype.getEventName = function() {
  */
 wtf.analysis.db.EventIndex.prototype.insertEvent = function(e) {
   if (e.eventType.name == this.eventName_) {
-    goog.base(this, 'insertEvent', e);
+    // We manually call base method instead of using goog.base because this
+    // method is called often enough to have a major impact on load time in
+    // debug mode.
+    wtf.analysis.db.EventList.prototype.insertEvent.call(this, e);
   }
 };

--- a/src/wtf/analysis/db/zoneindex.js
+++ b/src/wtf/analysis/db/zoneindex.js
@@ -51,6 +51,9 @@ wtf.analysis.db.ZoneIndex.prototype.getZone = function() {
  */
 wtf.analysis.db.ZoneIndex.prototype.insertEvent = function(e) {
   if (e.zone == this.zone_) {
-    goog.base(this, 'insertEvent', e);
+    // We manually call base method instead of using goog.base because this
+    // method is called often enough to have a major impact on load time
+    // in debug mode.
+    wtf.analysis.db.EventList.prototype.insertEvent.call(this, e);
   }
 };

--- a/src/wtf/analysis/event.js
+++ b/src/wtf/analysis/event.js
@@ -137,7 +137,9 @@ wtf.analysis.Event.comparer = function(a, b) {
  * @extends {wtf.analysis.Event}
  */
 wtf.analysis.ScopeEvent = function(eventType, zone, scope, time, args) {
-  goog.base(this, eventType, zone, scope, time, args);
+  // We manually call base method instead of using goog.base because this method
+  // is called often enough to have a major impact on load time in debug mode.
+  wtf.analysis.Event.call(this, eventType, zone, scope, time, args);
 };
 goog.inherits(wtf.analysis.ScopeEvent, wtf.analysis.Event);
 


### PR DESCRIPTION
The goog.base calls go away in compiled mode, but they are are slow
enough that they make debugging annoying. This change makes file
loading about 3 times faster in debug mode.
