### PR TITLE
Adding GCs to the trace via the debugger API.

### DIFF
--- a/injector/wtf-injector-chrome/BUILD.anvil
+++ b/injector/wtf-injector-chrome/BUILD.anvil
@@ -28,6 +28,8 @@ file_set(
         ':stripped_manifest',
         ':tracing_files',
         'background.js',
+        'debugger.js',
+        'extendedinfo.js',
         'extension.js',
         'options.js',
         'uri.js',

--- a/injector/wtf-injector-chrome/debugger.js
+++ b/injector/wtf-injector-chrome/debugger.js
@@ -1,0 +1,181 @@
+/**
+ * Copyright 2012 Google, Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+/**
+ * @fileoverview Debugger data proxy.
+ *
+ * @author benvanik@google.com (Ben Vanik)
+ */
+
+
+/**
+ * Debugger data proxy.
+ * This connects to a tab and sets up a debug session that is used for reading
+ * out events from the page.
+ *
+ * @param {number} tabId Tab ID.
+ * @param {!function(!Object)} queueData A function that queues event data for
+ *     sending to the target tab.
+ * @constructor
+ */
+var Debugger = function(tabId, queueData) {
+  /**
+   * Target tab ID.
+   * @type {number}
+   * @private
+   */
+  this.tabId_ = tabId;
+
+  /**
+   * Target debugee.
+   * @type {!Object}
+   * @private
+   */
+  this.debugee_ = {
+    tabId: this.tabId_
+  };
+
+  /**
+   * A function that queues event data for sending.
+   * @type {!function(!Object)}
+   * @private
+   */
+  this.queueData_ = queueData;
+
+  /**
+   * Whether this debugger is attached.
+   * @type {boolean}
+   */
+  this.attached_ = false;
+
+  /**
+   * Registered event handlers.
+   * @type {!Object}
+   * @private
+   */
+  this.eventHandlers_ = {
+    onEvent: this.onEvent_.bind(this),
+    onDetach: this.onDetach_.bind(this)
+  };
+
+  // Attach to the target tab.
+  chrome.debugger.attach(this.debugee_, '1.0', (function() {
+    this.attached_ = true;
+    this.beginListening_();
+  }).bind(this));
+
+  // Listen for incoming debugger events.
+  chrome.debugger.onEvent.addListener(this.eventHandlers_.onEvent);
+
+  // Listen for detaches. These are either from us or from the dev tools
+  // being attached to a page.
+  chrome.debugger.onDetach.addListener(this.eventHandlers_.onDetach);
+};
+
+
+/**
+ * Detaches the debugger from the tab.
+ */
+Debugger.prototype.dispose = function() {
+  if (this.attached_) {
+    this.attached_ = false;
+    chrome.debugger.detach(this.debugee_);
+  }
+
+  chrome.debugger.onEvent.removeListener(this.eventHandlers_.onEvent);
+  chrome.debugger.onDetach.removeListener(this.eventHandlers_.onDetach);
+};
+
+
+/**
+ * Handles incoming debugger detaches.
+ * @param {!{tabId: number}} source Source tab.
+ * @private
+ */
+Debugger.prototype.onDetach_ = function(source) {
+  if (source.tabId != this.debugee_.tabId) {
+    return;
+  }
+  if (!this.attached_) {
+    return;
+  }
+  this.attached_ = false;
+  this.dispose();
+};
+
+
+/**
+ * Begins listening for debugger events.
+ * @private
+ */
+Debugger.prototype.beginListening_ = function() {
+  chrome.debugger.sendCommand(this.debugee_, 'Timeline.start', {
+    // Limit call stack depth to keep messages small - if we ever need this
+    // data this can be increased.
+    'maxCallStackDepth': 1
+  });
+};
+
+
+/**
+ * Handles incoming debugger events.
+ * @param {!{tabId: number}} source Source tab.
+ * @param {string} method Remote debugger method name.
+ * @param {!Object} params Parameters.
+ * @private
+ */
+Debugger.prototype.onEvent_ = function(source, method, params) {
+  if (source.tabId != this.debugee_.tabId) {
+    return;
+  }
+
+  function logRecord(record, indent) {
+    indent += '  ';
+    console.log(indent + record.type);
+    if (record.children) {
+      for (var n = 0; n < record.children.length; n++) {
+        logRecord(record.children[n], indent);
+      }
+    }
+  }
+
+  switch (method) {
+    case 'Timeline.eventRecorded':
+      var record = params['record'];
+      this.processTimelineRecord_(record);
+      //logRecord(record, '');
+      break;
+  }
+};
+
+
+/**
+ * Processes a timeline record and generates event data.
+ * @param {!Object} record Timeline record.
+ * @private
+ */
+Debugger.prototype.processTimelineRecord_ = function(record) {
+  // Extract GCs.
+  if (record.type == 'GCEvent') {
+    var data = {
+      'type': 'GCEvent',
+      'startTime': record.startTime,
+      'endTime': record.endTime,
+      //'stackTrace': record.stackTrace,
+      'usedHeapSize': record.usedHeapSize,
+      'usedHeapSizeDelta': record.data.usedHeapSizeDelta
+    };
+    this.queueData_(data);
+  }
+
+  // Recursively check children.
+  if (record.children) {
+    for (var n = 0; n < record.children.length; n++) {
+      this.processTimelineRecord_(record.children[n]);
+    }
+  }
+};

--- a/injector/wtf-injector-chrome/extendedinfo.js
+++ b/injector/wtf-injector-chrome/extendedinfo.js
@@ -1,0 +1,122 @@
+/**
+ * Copyright 2012 Google, Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+/**
+ * @fileoverview Extended info data proxy.
+ *
+ * @author benvanik@google.com (Ben Vanik)
+ */
+
+
+/**
+ * Extended info data proxy.
+ * This connects to a tab and sets up extended info sources that are used for
+ * reading out extra data about a tab. The events are then piped through to the
+ * injected page for use in the data stream.
+ *
+ * @param {number} tabId Tab ID.
+ * @param {!Port} port Message port.
+ * @param {!Object} pageOptions Page options.
+ * @constructor
+ */
+var ExtendedInfo = function(tabId, port, pageOptions) {
+  /**
+   * Target tab ID.
+   * @type {number}
+   * @private
+   */
+  this.tabId_ = tabId;
+
+  /**
+   * Message port opened to the tab content script.
+   * @type {!Port}
+   * @private
+   */
+  this.port_ = port;
+
+  /**
+   * Page options.
+   * @type {!Object}
+   * @private
+   */
+  this.pageOptions_ = pageOptions;
+
+  // TODO(benvanik): use page options to determine whether to enable the
+  // debugger/extended info functionality.
+
+  /**
+   * Debugger source.
+   * @type {!Debugger}
+   * @private
+   */
+  this.debugger_ = new Debugger(this.tabId_, this.queueData.bind(this));
+
+  /**
+   * Data pending send.
+   * @type {!Array.<!Object>}
+   * @private
+   */
+  this.queuedData_ = [];
+
+  /**
+   * Registered event handlers.
+   * @type {!Object}
+   * @private
+   */
+  this.eventHandlers_ = {
+    onDisconnect: this.dispose.bind(this)
+  };
+
+  // Listen for disconnects.
+  port.onDisconnect.addListener(this.eventHandlers_.onDisconnect);
+};
+
+
+/**
+ * Detaches the info source from the target tab.
+ * After this is called the source should be discarded.
+ */
+ExtendedInfo.prototype.dispose = function() {
+  this.debugger_.dispose();
+
+  this.port_.onDisconnect.removeListener(this.eventHandlers_.onDisconnect);
+};
+
+
+/**
+ * Gets the tab ID of the target page.
+ * @return {number} Tab ID.
+ */
+ExtendedInfo.prototype.getTabId = function() {
+  return this.tabId_;
+};
+
+
+/**
+ * Queues event data for sending to the target tab.
+ * @param {!Object} data Event data.
+ */
+ExtendedInfo.prototype.queueData = function(data) {
+  this.queuedData_.push(data);
+
+  // TODO(benvanik): delay flush for a bit? 100ms? etc?
+  this.flush();
+};
+
+
+/**
+ * Flushes all pending event data to the target tab.
+ */
+ExtendedInfo.prototype.flush = function() {
+  // Send all pending data to the target tab content script.
+  this.port_.postMessage({
+    'command': 'trace_events',
+    'contents': this.queuedData_
+  });
+
+  this.queuedData_.length = 0;
+};

--- a/injector/wtf-injector-chrome/extension.js
+++ b/injector/wtf-injector-chrome/extension.js
@@ -37,6 +37,14 @@ var Extension = function() {
   // Listen for commands from content scripts.
   chrome.extension.onConnect.addListener(function(port) {
     if (port.name == 'injector') {
+      // Setup the extended info provider for the page.
+      var tab = port.sender.tab;
+      var options = this.getOptions();
+      var pageUrl = URI.canonicalize(tab.url);
+      var pageOptions = options.getPageOptions(pageUrl);
+      var extendedInfo = new ExtendedInfo(tab.id, port, pageOptions);
+
+      // Listen for messages from the page.
       port.onMessage.addListener(this.pageMessageReceived_.bind(this));
     }
   }.bind(this));
@@ -61,9 +69,9 @@ Extension.prototype.detectApplication_ = function() {
   // TODO(benvanik): some way of talking to the app to get the right URL.
   var options = this.options_;
   options.setDefaultEndpoint('page',
-      chrome.extension.getURL('app/maindisplay.html'));
+      //chrome.extension.getURL('app/maindisplay.html'));
       // TODO(benvanik): use debug URL somehow?
-      //'http://localhost:8080/app/maindisplay-debug.html');
+      'http://localhost:8080/app/maindisplay-debug.html');
 
   chrome.management.getAll(function(results) {
     for (var n = 0; n < results.length; n++) {

--- a/injector/wtf-injector-chrome/manifest.json
+++ b/injector/wtf-injector-chrome/manifest.json
@@ -11,6 +11,7 @@
   "permissions": [
     "chrome://favicon/",
     "cookies",
+    "debugger",
     "management",
     "storage",
     "tabs",
@@ -40,6 +41,8 @@
     "scripts": [
       "uri.js",
       "options.js",
+      "debugger.js",
+      "extendedinfo.js",
       "extension.js",
       "background.js"
     ]

--- a/injector/wtf-injector-chrome/wtf-injector.js
+++ b/injector/wtf-injector-chrome/wtf-injector.js
@@ -202,6 +202,15 @@ function setupCommunications() {
     name: 'injector'
   });
 
+  // Listen for data from the extension.
+  port.onMessage.addListener(function(data, port) {
+    switch (data['command']) {
+      case 'trace_events':
+        sendMessage(data);
+        break;
+    }
+  });
+
   // Setup a communication channel with the page via events.
   var channelElement = document;
   var localId = String(Number(Date.now()));

--- a/src/wtf/app/ui/nav/heatmappainter.js
+++ b/src/wtf/app/ui/nav/heatmappainter.js
@@ -54,6 +54,9 @@ wtf.app.ui.nav.HeatmapPainter = function(parentContext, db) {
   this.bars_.push(new wtf.app.ui.nav.HeatmapPainter.Bar_(db, 'branches', [
     'wtf.flow.branch'
   ]));
+  this.bars_.push(new wtf.app.ui.nav.HeatmapPainter.Bar_(db, 'GCs', [
+    'javascript#gc'
+  ]));
 
   var deferreds = [];
   for (var n = 0; n < this.bars_.length; n++) {

--- a/src/wtf/trace/providers/extendedinfoprovider.js
+++ b/src/wtf/trace/providers/extendedinfoprovider.js
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2012 Google, Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+/**
+ * @fileoverview Extension extended data proxy.
+ *
+ * @author benvanik@google.com (Ben Vanik)
+ */
+
+goog.provide('wtf.trace.providers.ExtendedInfoProvider');
+
+goog.require('wtf');
+goog.require('wtf.ipc');
+goog.require('wtf.ipc.Channel');
+goog.require('wtf.trace.Provider');
+goog.require('wtf.trace.events');
+
+
+
+/**
+ * Inserts data from the extension extended information proxy.
+ *
+ * @constructor
+ * @extends {wtf.trace.Provider}
+ */
+wtf.trace.providers.ExtendedInfoProvider = function() {
+  goog.base(this);
+
+  /**
+   * Custom event types.
+   * @type {!Object.<!Function>}
+   * @private
+   */
+  this.events_ = {
+    gc: wtf.trace.events.createScope(
+        'javascript#gc(uint32 usedHeapSize, uint32 usedHeapSizeDelta)')
+  };
+
+  /**
+   * DOM channel, if supported.
+   * This can be used to listen to notifications from the extension or send
+   * messages to the content script.
+   * @type {wtf.ipc.DomChannel}
+   * @private
+   */
+  this.extensionChannel_ = null;
+  if (!wtf.NODE) {
+    this.extensionChannel_ = wtf.ipc.openDomChannel(
+        goog.global.document,
+        'WtfContentScriptEvent');
+  }
+  this.registerDisposable(this.extensionChannel_);
+
+  // Listen for messages from the extension.
+  if (this.extensionChannel_) {
+    this.extensionChannel_.addListener(
+        wtf.ipc.Channel.EventType.MESSAGE, this.extensionMessage_, this);
+  }
+};
+goog.inherits(wtf.trace.providers.ExtendedInfoProvider, wtf.trace.Provider);
+
+
+/**
+ * Handles messages from the extension.
+ * @param {!Object} data Message data.
+ * @private
+ */
+wtf.trace.providers.ExtendedInfoProvider.prototype.extensionMessage_ =
+    function(data) {
+  switch (data['command']) {
+    case 'trace_events':
+      var contents = data['contents'];
+      for (var n = 0; n < contents.length; n++) {
+        var eventData = contents[n];
+        switch (eventData['type']) {
+          case 'GCEvent':
+            this.traceGc_(eventData);
+        }
+      }
+      break;
+  }
+};
+
+
+/**
+ * Traces a GC event.
+ * @param {!Object} data GC event data.
+ * @private
+ */
+wtf.trace.providers.ExtendedInfoProvider.prototype.traceGc_ = function(data) {
+  var timebase = wtf.timebase();
+  var startTime = data['startTime'] - timebase;
+  var endTime = data['endTime'] - timebase;
+  var usedHeapSize = data['usedHeapSize'];
+  var usedHeapSizeDelta = data['usedHeapSizeDelta'];
+  var scope = this.events_.gc(startTime, null, usedHeapSize, usedHeapSizeDelta);
+  scope.leave(undefined, endTime);
+};

--- a/src/wtf/trace/providers/providers.js
+++ b/src/wtf/trace/providers/providers.js
@@ -17,6 +17,7 @@ goog.require('wtf');
 goog.require('wtf.trace');
 goog.require('wtf.trace.providers.ConsoleProvider');
 goog.require('wtf.trace.providers.DomProvider');
+goog.require('wtf.trace.providers.ExtendedInfoProvider');
 goog.require('wtf.trace.providers.TimingProvider');
 
 
@@ -31,6 +32,7 @@ wtf.trace.providers.setup = function() {
   // Browser only:
   if (!wtf.NODE) {
     traceManager.addProvider(new wtf.trace.providers.DomProvider());
+    traceManager.addProvider(new wtf.trace.providers.ExtendedInfoProvider());
   }
 
   // Node only:

--- a/src/wtf/trace/scope.js
+++ b/src/wtf/trace/scope.js
@@ -155,27 +155,28 @@ wtf.trace.Scope.enterTyped = function(flow, time) {
  * be terminated.
  *
  * @param {*=} opt_result A value to return directly.
+ * @param {number=} opt_time Time for the leave; omit to use the current time.
  * @return {?} The value passed as {@code opt_result}.
  * @this {wtf.trace.Scope}
  */
-wtf.trace.Scope.prototype.leave = wtf.ENABLE_TRACING ? function(opt_result) {
-  // Time immediately after the scope - don't track our stuff.
-  // TODO(benvanik): allow for specifying time.
-  var time = wtf.now();
+wtf.trace.Scope.prototype.leave = wtf.ENABLE_TRACING ? function(
+    opt_result, opt_time) {
+      // Time immediately after the scope - don't track our stuff.
+      var time = opt_time || wtf.now();
 
-  // Terminate a flow, if one is attached.
-  if (this.flow_) {
-    this.flow_.terminate(undefined, time);
-    this.flow_ = undefined;
-  }
+      // Terminate a flow, if one is attached.
+      if (this.flow_) {
+        this.flow_.terminate(undefined, time);
+        this.flow_ = undefined;
+      }
 
-  // Append event.
-  wtf.trace.BuiltinEvents.leaveScope(time);
+      // Append event.
+      wtf.trace.BuiltinEvents.leaveScope(time);
 
-  // Return the scope to the pool.
-  // Note that we have no thresholding here and will grow forever.
-  var pool = wtf.trace.Scope.pool_;
-  pool.unusedScopes[pool.unusedIndex++] = this;
+      // Return the scope to the pool.
+      // Note that we have no thresholding here and will grow forever.
+      var pool = wtf.trace.Scope.pool_;
+      pool.unusedScopes[pool.unusedIndex++] = this;
 
-  return opt_result;
-} : goog.identityFunction;
+      return opt_result;
+    } : goog.identityFunction;

--- a/src/wtf/trace/trace.js
+++ b/src/wtf/trace/trace.js
@@ -31,6 +31,7 @@ goog.require('wtf.trace.Scope');
 goog.require('wtf.trace.SnapshottingSession');
 goog.require('wtf.trace.StreamingSession');
 goog.require('wtf.trace.TraceManager');
+goog.require('wtf.trace.util');
 goog.require('wtf.util.Options');
 
 
@@ -374,7 +375,4 @@ wtf.trace.mark = wtf.ENABLE_TRACING ? function(opt_msg, opt_time) {
  * @return {!T} The parameter, for chaining.
  * @template T
  */
-wtf.trace.ignoreListener = function(listener) {
-  listener['__wtf_ignore__'] = true;
-  return listener;
-};
+wtf.trace.ignoreListener = wtf.trace.util.ignoreListener;

--- a/src/wtf/trace/util.js
+++ b/src/wtf/trace/util.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2012 Google, Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+/**
+ * @fileoverview Trace utility functions.
+ * Most of these will be exported onto the {@see wtf.trace} namespace but are
+ * here to prevent dependency cycles.
+ *
+ * @author benvanik@google.com (Ben Vanik)
+ */
+
+goog.provide('wtf.trace.util');
+
+
+/**
+ * Marks an event listener as being ignored, meaning that it will not show up
+ * in traces.
+ * @param {!T} listener Event listener.
+ * @return {!T} The parameter, for chaining.
+ * @template T
+ */
+wtf.trace.util.ignoreListener = function(listener) {
+  listener['__wtf_ignore__'] = true;
+  return listener;
+};

--- a/src/wtf/ui/rangerenderer.js
+++ b/src/wtf/ui/rangerenderer.js
@@ -46,7 +46,7 @@ wtf.ui.RangeRenderer = function() {
 /**
  * Clear the accumulated ranges. Resetting with a different width is somewhat
  * expensive so should not be done frequently.
- * @param {number} width
+ * @param {number} width Width.
  */
 wtf.ui.RangeRenderer.prototype.reset = function(width) {
   if (this.width_ != width) {


### PR DESCRIPTION
Implements issue #28.

This adds the concept of 'Extended info' to the extension and tracing library. Currently this uses the Chrome remote debugger API to push GC event info down into the page where it is merged into the trace stream. In the future we can record paints/layouts/etc, as well as other information retrieved via privileged APIs (CPU use/etc).

GC display is currently kind of broken, but will be fixed in a future CL. The heatmap shows when GCs begin but does not correctly draw their duration.
