### PR TITLE
Cleaning up CommandManager and wiring up the UI to use it.

### DIFF
--- a/src/wtf/app/ui/nav/framebar.js
+++ b/src/wtf/app/ui/nav/framebar.js
@@ -23,8 +23,8 @@ goog.require('wtf.app.ui.nav.FramebarPainter');
 goog.require('wtf.app.ui.nav.HeatmapPainter');
 goog.require('wtf.app.ui.nav.framebar');
 goog.require('wtf.doc.View');
+goog.require('wtf.events');
 goog.require('wtf.events.EventType');
-goog.require('wtf.events.Keyboard');
 goog.require('wtf.events.KeyboardScope');
 goog.require('wtf.events.ListEventType');
 goog.require('wtf.ui.Control');
@@ -210,7 +210,7 @@ wtf.app.ui.nav.Framebar.prototype.createDom = function(dom) {
  */
 wtf.app.ui.nav.Framebar.prototype.setupKeyboardShortcuts_ = function() {
   var dom = this.getDom();
-  var keyboard = wtf.events.Keyboard.getWindowKeyboard(dom.getWindow());
+  var keyboard = wtf.events.getWindowKeyboard(dom);
   var keyboardScope = new wtf.events.KeyboardScope(keyboard);
   this.registerDisposable(keyboardScope);
   keyboardScope.addShortcut('space', function() {

--- a/src/wtf/app/ui/tabbar.js
+++ b/src/wtf/app/ui/tabbar.js
@@ -19,7 +19,7 @@ goog.require('goog.dom.classes');
 goog.require('goog.events.EventType');
 goog.require('goog.soy');
 goog.require('wtf.app.ui.tabbar');
-goog.require('wtf.events.Keyboard');
+goog.require('wtf.events');
 goog.require('wtf.events.KeyboardScope');
 goog.require('wtf.ui.Control');
 
@@ -72,7 +72,7 @@ wtf.app.ui.Tabbar = function(documentView, parentElement) {
    */
   this.selectedTab_ = null;
 
-  var keyboard = wtf.events.Keyboard.getWindowKeyboard(dom.getWindow());
+  var keyboard = wtf.events.getWindowKeyboard(dom);
 
   /**
    * Keyboard scope for tab selection.

--- a/src/wtf/app/ui/toolbar.gss
+++ b/src/wtf/app/ui/toolbar.gss
@@ -70,6 +70,8 @@
 .wtfAppUiToolbarButtons {
   float: left;
 }
+.wtfAppUiToolbarButtonOpen {}
 .wtfAppUiToolbarButtonShare {}
 .wtfAppUiToolbarButtonSave {}
 .wtfAppUiToolbarButtonSettings {}
+.wtfAppUiToolbarButtonHelp {}

--- a/src/wtf/app/ui/toolbar.soy
+++ b/src/wtf/app/ui/toolbar.soy
@@ -38,6 +38,9 @@
         <!--[viewer info]-->
       </div>
       <div class="{css kButtonBar} {css kRight} {css wtfAppUiToolbarButtons}">
+        <div class="{css kButton} {css kMenuButton} {css kDisabled} {css wtfAppUiToolbarButtonOpen}">
+          Open
+        </div>
         <div class="{css kButton} {css kMenuButton} {css kDisabled} {css wtfAppUiToolbarButtonShare}">
           Share
         </div>
@@ -48,6 +51,9 @@
           title="Settings">
           <img alt="Settings" src="icons/settings.svg">
         </a>
+        <div class="{css kButton} {css kMenuButton} {css kDisabled} {css wtfAppUiToolbarButtonHelp}">
+          Help
+        </div>
       </div>
     </div>
   </div>

--- a/src/wtf/app/ui/tracks/trackinfobar.js
+++ b/src/wtf/app/ui/tracks/trackinfobar.js
@@ -15,8 +15,8 @@ goog.provide('wtf.app.ui.tracks.TrackInfoBar');
 
 goog.require('goog.soy');
 goog.require('wtf.app.ui.tracks.trackinfobar');
+goog.require('wtf.events');
 goog.require('wtf.events.EventType');
-goog.require('wtf.events.Keyboard');
 goog.require('wtf.events.KeyboardScope');
 goog.require('wtf.ui.Control');
 goog.require('wtf.ui.SearchControl');
@@ -54,7 +54,7 @@ wtf.app.ui.tracks.TrackInfoBar = function(tracksPanel, parentElement) {
   this.registerDisposable(this.searchControl_);
 
   // Setup keyboard shortcuts.
-  var keyboard = wtf.events.Keyboard.getWindowKeyboard(dom.getWindow());
+  var keyboard = wtf.events.getWindowKeyboard(dom);
   var keyboardScope = new wtf.events.KeyboardScope(keyboard);
   this.registerDisposable(keyboardScope);
   keyboardScope.addShortcut('ctrl+f', function() {

--- a/src/wtf/events/events.js
+++ b/src/wtf/events/events.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2012 Google, Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+/**
+ * @fileoverview Events utility namespace.
+ *
+ * @author benvanik@google.com (Ben Vanik)
+ */
+
+goog.provide('wtf.events');
+
+goog.require('wtf.events.CommandManager');
+goog.require('wtf.events.Keyboard');
+
+
+/**
+ * Alias for {@see wtf.events.Keyboard#getWindowKeyboard}.
+ */
+wtf.events.getWindowKeyboard = wtf.events.Keyboard.getWindowKeyboard;
+
+
+/**
+ * Alias for {@see wtf.events.CommandManager#getShared}.
+ */
+wtf.events.getCommandManager = wtf.events.CommandManager.getShared;

--- a/src/wtf/hud/overlay.js
+++ b/src/wtf/hud/overlay.js
@@ -21,7 +21,7 @@ goog.require('goog.dom.classes');
 goog.require('goog.soy');
 goog.require('goog.string');
 goog.require('goog.style');
-goog.require('wtf.events.Keyboard');
+goog.require('wtf.events');
 goog.require('wtf.events.KeyboardScope');
 goog.require('wtf.hud.LiveGraph');
 goog.require('wtf.hud.SettingsDialog');
@@ -112,7 +112,7 @@ wtf.hud.Overlay = function(session, options, opt_parentElement) {
       session, options, this.getChildElement('wtfHudGraph'));
   this.registerDisposable(this.liveGraph_);
 
-  var keyboard = wtf.events.Keyboard.getWindowKeyboard(dom.getWindow());
+  var keyboard = wtf.events.getWindowKeyboard(dom);
 
   /**
    * Keyboard shortcut scope.

--- a/src/wtf/ui/dialog.js
+++ b/src/wtf/ui/dialog.js
@@ -18,7 +18,7 @@ goog.require('goog.Disposable');
 goog.require('goog.dom');
 goog.require('goog.dom.TagName');
 goog.require('goog.style');
-goog.require('wtf.events.Keyboard');
+goog.require('wtf.events');
 goog.require('wtf.events.KeyboardScope');
 goog.require('wtf.timing');
 goog.require('wtf.ui.Control');
@@ -47,7 +47,7 @@ wtf.ui.Dialog = function(options, parentElement, opt_dom) {
   var dom = this.getDom();
 
   // Setup keyboard handlers for closing/etc.
-  var keyboard = wtf.events.Keyboard.getWindowKeyboard(dom.getWindow());
+  var keyboard = wtf.events.getWindowKeyboard(dom);
   var keyboardScope = new wtf.events.KeyboardScope(keyboard);
   this.registerDisposable(keyboardScope);
   keyboardScope.addShortcut('esc', this.close, this);

--- a/src/wtf/ui/searchcontrol.js
+++ b/src/wtf/ui/searchcontrol.js
@@ -16,8 +16,8 @@ goog.provide('wtf.ui.SearchControl');
 goog.require('goog.dom.TagName');
 goog.require('goog.dom.classes');
 goog.require('goog.events.EventType');
+goog.require('wtf.events');
 goog.require('wtf.events.EventType');
-goog.require('wtf.events.Keyboard');
 goog.require('wtf.ui.Control');
 
 
@@ -49,7 +49,7 @@ wtf.ui.SearchControl = function(parentElement, opt_dom) {
   var eh = this.getHandler();
 
   // Manage keyboard bindings.
-  var keyboard = wtf.events.Keyboard.getWindowKeyboard(dom.getWindow());
+  var keyboard = wtf.events.getWindowKeyboard(dom);
   var keyboardSuspended = false;
   eh.listen(el, goog.events.EventType.FOCUS, function() {
     if (keyboardSuspended) {


### PR DESCRIPTION
This allows for different parts of the app/keyboard hotkeys/etc to talk
to each other without having to be directly connected. Not to be abused,
but useful for things like toolbars with global commands.

Also setting up some aliases on wtf.events to make code less verbose.

Prep for issue #35, adding the help screen.
