### PR TITLE
Scope stack auto unwinding at trace time.

### DIFF
--- a/src/wtf/trace/trace.js
+++ b/src/wtf/trace/trace.js
@@ -341,7 +341,10 @@ wtf.trace.popZone = wtf.ENABLE_TRACING ? function() {
  * @return {!wtf.trace.Scope} An initialized scope object.
  */
 wtf.trace.enterScope = wtf.ENABLE_TRACING ?
-    wtf.trace.Scope.enter : function(opt_msg, opt_flow, opt_time) {
+    function(opt_msg, opt_flow, opt_time) {
+      return wtf.trace.BuiltinEvents.enterScope(
+          opt_time || wtf.now(), opt_flow, opt_msg);
+    } : function(opt_msg, opt_flow, opt_time) {
       return wtf.trace.Scope.dummy;
     };
 

--- a/src/wtf/ui/resizablecontrol.js
+++ b/src/wtf/ui/resizablecontrol.js
@@ -147,6 +147,9 @@ wtf.ui.ResizableControl = function(orientation, splitterClassName,
 
   // Always trigger a resize once style is available.
   wtf.timing.setImmediate(function() {
+    if (this.isDisposed()) {
+      return;
+    }
     this.sizeChanged();
   }, this);
 };

--- a/test/test-uncompiled.html
+++ b/test/test-uncompiled.html
@@ -35,7 +35,7 @@
   <script>
     window.onload = function() {
       var someLink = document.getElementById('someLink');
-      someLink.onclick = function(e) {
+      someLink.addEventListener('click', function(e) {
         e.preventDefault();
 
         // Enter scope
@@ -53,7 +53,7 @@
         }, 0);
 
         scope.leave();
-      };
+      });
 
       function unscopedMethod(x) {
         x++;


### PR DESCRIPTION
This automatically unwinds scopes when they are unmatched. This is designed
to make the exception case better.
It adds a minor amount of time to scope leaves (perf test per-call overhead
went from 0.000172ms to 0.000176ms). Likely still room for optimization.
Fixes #53.

Fix an exception that occurs when rapidly showing and hiding the HUD.
