### PR TITLE
Makes snapshots focus the popup window and improves snapshot perf.

### DIFF
--- a/injector/wtf-injector-chrome/wtf-injector.js
+++ b/injector/wtf-injector-chrome/wtf-injector.js
@@ -244,7 +244,7 @@ function setupCommunications() {
           'command': 'show_snapshot',
           'page_url': data['page_url'],
           'content_type': data['content_type'],
-          'contents': convertUint8ArraysToArrays(data['contents'])
+          'contents': data['contents']
         });
         break;
     }

--- a/src/wtf/app/ui/maindisplay.gss
+++ b/src/wtf/app/ui/maindisplay.gss
@@ -28,7 +28,7 @@
   position: absolute;
   width: 100%;
   height: 100%;
-  margin-top: 50%;
+  top: 50%;
   text-align: center;
 }
 

--- a/src/wtf/app/ui/maindisplay.js
+++ b/src/wtf/app/ui/maindisplay.js
@@ -102,12 +102,15 @@ wtf.app.ui.MainDisplay = function(
    * @type {wtf.ipc.Channel}
    * @private
    */
-  this.channel_ = wtf.ipc.connectToParentWindow();
-  if (this.channel_) {
-    this.channel_.addListener(
-        wtf.ipc.Channel.EventType.MESSAGE,
-        this.channelMessage_, this);
-  }
+  this.channel_ = null;
+  wtf.ipc.connectToParentWindow(function(channel) {
+    if (channel) {
+      this.channel_ = channel;
+      this.channel_.addListener(
+          wtf.ipc.Channel.EventType.MESSAGE,
+          this.channelMessage_, this);
+    }
+  }, this);
 
   // Setup command manager.
   this.commandManager_.registerSimpleCommand(
@@ -274,8 +277,10 @@ wtf.app.ui.MainDisplay.prototype.handleSnapshotCommand_ = function(data) {
 
   // Convert data from Arrays to ensure we are typed all the way through.
   for (var n = 0; n < datas.length; n++) {
-    if (!(datas[n] instanceof Uint8Array)) {
+    if (goog.isArray(datas[n])) {
       datas[n] = wtf.io.createByteArrayFromArray(datas[n]);
+    } else if (goog.isString(datas[n])) {
+      datas[n] = wtf.io.stringToNewByteArray(datas[n]);
     }
   }
 

--- a/src/wtf/hud/overlay.js
+++ b/src/wtf/hud/overlay.js
@@ -26,6 +26,7 @@ goog.require('wtf.events.KeyboardScope');
 goog.require('wtf.hud.LiveGraph');
 goog.require('wtf.hud.SettingsDialog');
 goog.require('wtf.hud.overlay');
+goog.require('wtf.io');
 goog.require('wtf.io.BufferedHttpWriteStream');
 goog.require('wtf.ipc');
 goog.require('wtf.ipc.Channel');
@@ -541,12 +542,20 @@ wtf.hud.Overlay.prototype.sendSnapshotToPage_ = function(opt_endpoint) {
   if (goog.string.startsWith(endpoint, 'chrome-extension://')) {
     // Opening in an extension window, need to marshal through the content
     // script to get it open.
+
+    // Since extension channels cannot take the typed arrays we convert to
+    // a string to make it flow faster through the system.
+    var stringBuffers = [];
+    for (var n = 0; n < buffers.length; n++) {
+      stringBuffers.push(wtf.io.byteArrayToString(buffers[n]));
+    }
+
     this.extensionChannel_.postMessage({
       'command': 'show_snapshot',
       'page_url': endpoint,
       'content_type': 'application/x-extension-wtf-trace',
-      'contents': buffers
-    }, buffers);
+      'contents': stringBuffers
+    });
   } else {
     // Create window and show.
     var target = window.open(endpoint, 'wtf_ui');

--- a/src/wtf/io/io.js
+++ b/src/wtf/io/io.js
@@ -194,6 +194,21 @@ wtf.io.stringToByteArray = function(value, target) {
 };
 
 
+/**
+ * Converts the given string to a byte array.
+ * @param {string} value String representation of a byte array.
+ * @return {wtf.io.ByteArray} Byte array, if the string was valid.
+ */
+wtf.io.stringToNewByteArray = function(value) {
+  // TODO(benvanik): optimize to create no garbage
+  var result = goog.crypt.base64.decodeStringToByteArray(value);
+  if (!result) {
+    return null;
+  }
+  return wtf.io.createByteArrayFromArray(result);
+};
+
+
 
 /**
  * Interface describing classes that can convert floating point numbers to


### PR DESCRIPTION
This uses chrome extension APIs instead of window.open to open the UI.
It also changes data into base64 _before_ sending across the extension
pipeline to prevent repeated JSON encodes/decodes of the large arrays.
Fixes #99.
