### PR TITLE
Fixes issues that arise between a manually embedded wtf and the injector.

### DIFF
--- a/BUILD.anvil
+++ b/BUILD.anvil
@@ -151,8 +151,8 @@ closure_js_library(
         '--define=wtf.ENABLE_TRACING=true',
         '--define=wtf.hud.exports.ENABLE_EXPORTS=true',
         '--define=wtf.trace.exports.ENABLE_EXPORTS=true',
-        ],
-    wrap_with_global='window')
+        '--output_wrapper="if(!window.wtf){(function(){%output%}).call(window);}"',
+        ])
 
 file_set(
     name='wtf_trace_web_debug',

--- a/injector/wtf-injector-chrome/options.js
+++ b/injector/wtf-injector-chrome/options.js
@@ -247,6 +247,9 @@ Options.prototype.getDefaultPageOptions = function(url) {
   ];
 
   var options = {
+    // The presence of this indicates that the options come from the injector.
+    'wtf.injector': true,
+
     'wtf.trace.session.maximumMemoryUsage': 128 * 1024 * 1024,
     'wtf.hud.app.mode': this.defaultEndpoint_.mode,
     'wtf.hud.app.endpoint': this.defaultEndpoint_.endpoint,
@@ -295,6 +298,13 @@ Options.prototype.getPageOptions = function(url) {
  * @param {!Object} options Options object.
  */
 Options.prototype.setPageOptions = function(url, options) {
+  // If the options from the page don't have the sentinel, ignore.
+  // This prevents pages that override the options from manual embedding
+  // from overwritting injector settings.
+  if (!options['wtf.injector']) {
+    return;
+  }
+
   // Cleanup by removing all defaults that are still the same.
   var defaultOptions = this.getDefaultPageOptions(url);
   var cleanedOptions = {};


### PR DESCRIPTION
Prevents the tracing code from clobbering itself and prevents manual options from getting saved into the extension storage.
Fixes #108.
