### PR TITLE
Adding a simple benchmark runner HTML page and node script.

### DIFF
--- a/scripts/run-benchmarks.js
+++ b/scripts/run-benchmarks.js
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+/**
+ * Copyright 2012 Google, Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+/**
+ * @fileoverview node.js runner.
+ *
+ * @author benvanik@google.com (Ben Vanik)
+ */
+
+var fs = require('fs');
+var vm = require('vm');
+
+var benchmark = require('../src/wtf/testing/benchmark');
+var benchmarkList = require('../test/benchmarks').value;
+
+global.benchmark = benchmark;
+global.wtf = require('../build-out/wtf_node_js_compiled');
+
+
+function padLeft(value, width) {
+  value = String(value);
+  while (value.length < width) {
+    value = value + ' ';
+  }
+  return value;
+};
+
+
+function padRight(value, width) {
+  value = String(value);
+  while (value.length < width) {
+    value = ' ' + value;
+  }
+  return value;
+};
+
+
+var PAD_RIGHT = 14;
+
+
+/**
+ * Logs a benchmark error.
+ * @param {string} msg Message.
+ * @param {string=} opt_benchmarkName Benchmark that was running when the error
+ *     occurred.
+ */
+global.reportBenchmarkError = function(msg, opt_benchmarkName) {
+  console.log(msg);
+};
+
+
+/**
+ * Logs a benchmark result.
+ * @param {string} benchmarkName Benchmark name.
+ * @param {{
+ *   runCount: number,
+ *   totalTime: number,
+ *   userTime: number,
+ *   meanTime: number
+ * }} data Result data.
+ */
+global.reportBenchmarkResult = function(benchmarkName, data) {
+  console.log(
+      padLeft(benchmarkName, 32) + ' ' +
+      padRight(data.runCount, PAD_RIGHT) + ' ' +
+      padRight((data.totalTime * 1000).toFixed(3) + 'ms', PAD_RIGHT) + ' ' +
+      padRight((data.meanTime * 1000).toFixed(5) + 'ms', PAD_RIGHT));
+};
+
+
+// Get the list of tests to run.
+var benchmarkNames = process.argv.slice(2);
+
+// Remove bad entries.
+for (var n = benchmarkNames.length - 1; n >= 0; n--) {
+  if (!benchmarkNames[n].length) {
+    benchmarkNames.splice(n, 1);
+  }
+}
+
+// If nothing provided, run all tests.
+if (!benchmarkNames.length) {
+  for (var n = 0; n < benchmarkList.length; n++) {
+    var entry = benchmarkList[n];
+    if (entry) {
+      benchmarkNames.push(entry.name);
+    }
+  }
+}
+
+// TODO(benvanik): fuzzy search through testNames - if any contain *, lookup
+// deps to find all matching namespaces.
+
+// Sort test names.
+// TODO(benvanik): sort by namespaces?
+benchmarkNames.sort(function(a, b) {
+  return a < b;
+});
+
+// Require all benchmark files.
+for (var n = 0; n < benchmarkNames.length; n++) {
+  var name = benchmarkNames[n];
+  var entry = null;
+  for (var m = 0; m < benchmarkList.length; m++) {
+    if (benchmarkList[m] && benchmarkList[m].name == name) {
+      entry = benchmarkList[m];
+      break;
+    }
+  }
+  if (entry) {
+    var scriptUrl = './test/benchmarks/' + entry.script;
+		vm.runInThisContext(fs.readFileSync(scriptUrl), scriptUrl);
+  } else {
+    reportBenchmarkError('Benchmark entry not found: ' + name);
+  }
+}
+
+console.log(
+      padLeft('[name]', 32) + ' ' +
+      padRight('[count]', PAD_RIGHT) + ' ' +
+      padRight('[total]', PAD_RIGHT) + ' ' +
+      padRight('[mean]', PAD_RIGHT));
+
+// Launch the run.
+benchmark.run.apply(null, benchmarkNames);

--- a/scripts/run-benchmarks.sh
+++ b/scripts/run-benchmarks.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Copyright 2012 Google Inc. All Rights Reserved.
+
+# Run benchmarks quickly.
+# This requires up-to-date deps files, produced by 'anvil build :deps'.
+#
+# If trying to test in an automated environment, prefer using the :test rule:
+#   anvil build :test
+
+
+# Fast build and ensure test dependencies exist.
+./third_party/anvil-build/anvil-local.sh build :debug :release
+
+
+GREP="$1"
+if [ -z $GREP ]; then
+  GREP=""
+  echo "Running all benchmarks..."
+else
+  echo "Running benchmarks matching '$GREP'..."
+fi
+
+./scripts/run-benchmarks.js $GREP

--- a/scripts/update-benchmarks.sh
+++ b/scripts/update-benchmarks.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Copyright 2012 Google Inc. All Rights Reserved.
+
+# Updates the benchmarks index file, used to select and run benchmarks.
+
+# This must currently run from the root of the repo
+# TODO(benvanik): make this runnable from anywhere (find git directory?)
+if [ ! -d ".git" ]; then
+  echo "This script must be run from the root of the repository (the folder containing .git)"
+  exit 1
+fi
+
+# TODO(benvanik): list *.js, see if it contains any benchmark.register() functions

--- a/src/wtf/testing/benchmark.html
+++ b/src/wtf/testing/benchmark.html
@@ -1,0 +1,179 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>wtf benchmark</title>
+    <script src="../../../wtf_trace_web_js_compiled.js"></script>
+    <script src="../../../node_modules/benchmark/benchmark.js"></script>
+    <script src="benchmark.js"></script>
+    <script src="../../../test/benchmarks.js"></script>
+  </head>
+  <body>
+    <table id="results">
+      <tr>
+        <td>[name]</td>
+        <td>[count]</td>
+        <td>[total]</td>
+        <td>[mean]</td>
+      </tr>
+    </table>
+    <script>
+
+/**
+ * Injects a function into the page.
+ * @param {!Function} fn Function to inject.
+ * @param {Array=} opt_args Arguments array. All must be string serializable.
+ */
+function injectScriptFunction(fn, opt_args) {
+  // Header to let users know what's up.
+  var header = [
+    '/* Web Tracing Framework injected benchmark function: ' + fn.name + ' */'
+  ].join('\n');
+
+  // Format args as strings that can go in the source.
+  var args = opt_args || [];
+  for (var n = 0; n < args.length; n++) {
+    if (typeof args[n] == 'string') {
+      // TODO(benvanik): escape
+      args[n] = '"' + args[n] + '"';
+    }
+  }
+  args = args.join(',');
+
+  // TODO(benvanik): escape fn source
+  var source = String(fn);
+
+  // Create script tag.
+  document.write('<script>' + header + '\n\n(' + source + ')(' + args + ');' +
+      '</sc' + 'ript>');
+};
+
+
+/**
+ * Sets up the benchmarks, loading the list and beginning the tests.
+ */
+function setupTesting() {
+  // Get the list of tests to run.
+  var benchmarkNames = [];
+  var query = window.location.search;
+  if (query.length) {
+    query = query.substring(1);
+    query = query.split('&')
+  }
+  for (var n = 0; n < query.length; n++) {
+    var tuple = query[n].split('=');
+    switch (tuple[0]) {
+      case 'tests':
+        benchmarkNames = tuple[1].split(',');
+        break;
+    }
+  }
+
+  // Remove bad entries.
+  for (var n = benchmarkNames.length - 1; n >= 0; n--) {
+    if (!benchmarkNames[n].length) {
+      benchmarkNames.splice(n, 1);
+    }
+  }
+
+  // If nothing provided, run all tests.
+  if (!benchmarkNames.length) {
+    for (var n = 0; n < benchmarkList.length; n++) {
+      var entry = benchmarkList[n];
+      if (entry) {
+        benchmarkNames.push(entry.name);
+      }
+    }
+  }
+
+  // TODO(benvanik): fuzzy search through testNames - if any contain *, lookup
+  // deps to find all matching namespaces.
+
+  // Sort test names.
+  // TODO(benvanik): sort by namespaces?
+  benchmarkNames.sort(function(a, b) {
+    return a < b;
+  });
+
+  // Set page title.
+  var prettyNames = [];
+  for (var n = 0; n < benchmarkNames.length; n++) {
+    prettyNames.push(benchmarkNames[n].replace('_test', ''));
+  }
+  document.title = 'WTF Benchmark: ' + prettyNames.join(', ');
+
+  // Require all benchmark files.
+  for (var n = 0; n < benchmarkNames.length; n++) {
+    var name = benchmarkNames[n];
+    var entry = null;
+    for (var m = 0; m < benchmarkList.length; m++) {
+      if (benchmarkList[m] && benchmarkList[m].name == name) {
+        entry = benchmarkList[m];
+        break;
+      }
+    }
+    if (entry) {
+      var scriptUrl = '../../../test/benchmarks/' + entry.script;
+      document.write('<script src="' + scriptUrl + '"></sc' + 'ript>');
+    } else {
+      reportBenchmarkError('Benchmark entry not found: ' + name);
+    }
+  }
+
+  // Launch the run.
+  injectScriptFunction(function(benchmarkNames) {
+    benchmark.run(benchmarkNames);
+  }, benchmarkNames);
+}
+
+
+/**
+ * Logs a benchmark error.
+ * @param {string} msg Message.
+ * @param {string=} opt_benchmarkName Benchmark that was running when the error
+ *     occurred.
+ */
+function reportBenchmarkError(msg, opt_benchmarkName) {
+  if (window.console) {
+    window.console.log(msg);
+  }
+
+  var errorDiv = document.createElement('div');
+  errorDiv.id = 'error';
+  errorDiv.innerText = msg;
+  document.body.insertBefore(errorDiv, document.body.firstChild);
+};
+
+
+/**
+ * Logs a benchmark result.
+ * @param {string} benchmarkName Benchmark name.
+ * @param {{
+ *   runCount: number,
+ *   totalTime: number,
+ *   userTime: number,
+ *   meanTime: number
+ * }} data Result data.
+ */
+function reportBenchmarkResult(benchmarkName, data) {
+  if (window.console) {
+    window.console.log(benchmarkName, data);
+  }
+
+  var row = document.createElement('tr');
+  row.innerHTML = [
+    '<td>' + benchmarkName + '</td>',
+    '<td>' + data.runCount + '</td>',
+    '<td>' + (data.totalTime * 1000).toFixed(3) + 'ms' + '</td>',
+    '<td>' + (data.meanTime * 1000).toFixed(5) + 'ms' + '</td>'
+  ].join('');
+
+  var resultsEl = document.getElementById('results');
+  resultsEl.appendChild(row);
+};
+
+
+setupTesting();
+
+    </script>
+  </body>
+</html>

--- a/src/wtf/testing/benchmark.js
+++ b/src/wtf/testing/benchmark.js
@@ -1,0 +1,115 @@
+/**
+ * Copyright 2012 Google, Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+/**
+ * @fileoverview Benchmark runner.
+ * This file is used by both node.js and the browser, so do not use any
+ * platform-specific APIs.
+ *
+ * The only safe functions to use:
+ * reportBenchmarkResult(benchmarkName, {
+ *   runCount: number,
+ *   totalTime: number,
+ *   userTime: number,
+ *   meanTime: number
+ * });
+ * reportBenchmarkError(msg, opt_benchmarkName);
+ *
+ * @author benvanik@google.com (Ben Vanik)
+ */
+
+
+(function(global, exports) {
+
+  var Benchmark = global.Benchmark;
+  var wtf = global.wtf;
+  if (typeof require !== 'undefined') {
+    Benchmark = require('benchmark');
+    wtf = require('../../../build-out/wtf_node_js_compiled');
+  }
+
+  /**
+   * All registered benchmarks, by name.
+   * @type {!Object.<{
+   *   name: string,
+   *   fn: Function
+   * }>}
+   */
+  var registeredBenchmarks = {};
+
+
+  /**
+   * Defines a benchmark.
+   * This should be called from the benchmark script files as loaded. The name
+   * given is used for display and test filtering.
+   * @param {string} name Benchmark name.
+   * @param {Function} fn [description].
+   */
+  exports.register = function(name, fn) {
+    registeredBenchmarks[name] = {
+      name: name,
+      fn: fn
+    };
+  };
+
+
+  /**
+   * Runs a list of benchmarks.
+   * @param {...string} var_arg A list of benchmark names to run.
+   */
+  exports.run = function(var_arg) {
+    var suite = new Benchmark.Suite('WTF', {
+      'onCycle': function(e) {
+        //console.log(e);
+      },
+      'onError': function(e) {
+        console.log(e);
+      }
+    });
+
+    var names = arguments;
+    for (var n = 0; n < names.length; n++) {
+      var entry = registeredBenchmarks[names[n]];
+      if (!entry) {
+        reportBenchmarkError('Benchmark "' + names[n] + '" not found.');
+        continue;
+      }
+
+      suite.add(entry.name, {
+        'fn': function() {
+          return entry.fn(123, 567);
+        },
+        'setup': function() {
+          wtf.trace.reset();
+        },
+        'teardown': function() {
+          wtf.trace.reset();
+        },
+        'onComplete': function() {
+          reportBenchmarkResult(this.name, {
+            runCount: this.count,
+            totalTime: this.times.elapsed,
+            userTime: this.times.elapsed,
+            meanTime: this.stats.mean
+          });
+        }
+      });
+    }
+
+    wtf.trace.start({
+      'wtf.trace.mode': 'snapshotting',
+      'wtf.trace.target': 'file://'
+    });
+
+    suite.run({
+      //'async': true,
+      'delay': 1,
+      'initCount': 10000
+    });
+  };
+
+}(this, typeof exports === 'undefined' ? this.benchmark = {} : exports));

--- a/test/benchmarks.js
+++ b/test/benchmarks.js
@@ -1,0 +1,5 @@
+// Generated file; see update-benchmarks.sh for more information.
+var benchmarkList = [
+  { name: 'simple', script: 'simple.js' },
+];
+if (typeof exports !== 'undefined') { exports.value = benchmarkList; }

--- a/test/benchmarks/simple.js
+++ b/test/benchmarks/simple.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2012 Google, Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+/**
+ * @fileoverview Benchmark file.
+ *
+ * @author benvanik@google.com (Ben Vanik)
+ */
+
+
+benchmark.register('simple', function(a, b) {
+  var scope = wtf.trace.enterScope();
+  //
+  scope.leave();
+  return a + b;
+});


### PR DESCRIPTION
This runs the benchmarks/simple.js file with benchmarkjs and outputs the
results. More benchmarks can be added manually. In the future
update-benchmarks.sh will update the listing.
