### PR TITLE
Adding wtf.version.* and wtf.trace.getApiVersion to enable versioning.

### DIFF
--- a/src/wtf/analysis/sources/binarytracesource.js
+++ b/src/wtf/analysis/sources/binarytracesource.js
@@ -15,7 +15,6 @@ goog.provide('wtf.analysis.sources.BinaryTraceSource');
 
 goog.require('goog.asserts');
 goog.require('goog.math.Long');
-goog.require('wtf');
 goog.require('wtf.analysis.Event');
 goog.require('wtf.analysis.EventType');
 goog.require('wtf.analysis.Flow');
@@ -193,13 +192,9 @@ wtf.analysis.sources.BinaryTraceSource.prototype.readTraceHeader_ =
   }
 
   // Read version information to ensure we support the format.
-  // wtf.VERSION
+  // wtf.version.getBuild()
+  // We don't actually need these to match.
   var wtfVersion = buffer.readUint32();
-  if (wtfVersion != wtf.VERSION) {
-    // Runtime version mismatch.
-    goog.asserts.fail('Runtime version mismatch');
-    return false;
-  }
   // wtf.trace.Session.FORMAT_VERSION
   var formatVersion = buffer.readUint32();
   if (formatVersion != wtf.analysis.sources.BinaryTraceSource.FORMAT_VERSION) {

--- a/src/wtf/trace/exports.js
+++ b/src/wtf/trace/exports.js
@@ -50,6 +50,10 @@ wtf.trace.exports.ENABLE_EXPORTS = false;
 
 
 if (wtf.trace.exports.ENABLE_EXPORTS) {
+  goog.exportSymbol(
+      'wtf.trace.getApiVersion',
+      wtf.trace.getApiVersion);
+
   // wtf.trace.prepare
   goog.exportSymbol(
       'wtf.trace.prepare',

--- a/src/wtf/trace/session.js
+++ b/src/wtf/trace/session.js
@@ -19,6 +19,7 @@ goog.require('goog.math.Long');
 goog.require('wtf');
 goog.require('wtf.trace.BuiltinEvents');
 goog.require('wtf.trace.Scope');
+goog.require('wtf.version');
 
 
 
@@ -166,7 +167,7 @@ wtf.trace.Session.prototype.writeTraceHeader = function(buffer) {
   buffer.writeUint32(0xDEADBEEF);
 
   // Write version information.
-  buffer.writeUint32(wtf.VERSION);
+  buffer.writeUint32(wtf.version.getBuild());
   buffer.writeUint32(wtf.trace.Session.FORMAT_VERSION);
 
   // Write context information.

--- a/src/wtf/trace/trace.js
+++ b/src/wtf/trace/trace.js
@@ -37,6 +37,17 @@ goog.require('wtf.util.Options');
 
 
 /**
+ * Gets a version number indicating the API version of the tracing methods.
+ * This can be used by wrapper libraries to conditionally enable/disable
+ * methods based on whether the version matches.
+ * @return {number} Version number.
+ */
+wtf.trace.getApiVersion = function() {
+  return 1;
+};
+
+
+/**
  * Trace manager setup by {@see wtf.trace#prepare}.
  * @type {wtf.trace.TraceManager}
  * @private

--- a/src/wtf/version.js
+++ b/src/wtf/version.js
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2012 Google, Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+/**
+ * @fileoverview WTF version utilities.
+ *
+ * @author benvanik@google.com (Ben Vanik)
+ */
+
+goog.provide('wtf.version');
+
+goog.require('goog.string');
+
+
+/**
+ * Gets the current build number as an integer value.
+ * This can be used to compare two build numbers using normal integer
+ * comparison. If you need a human-readable build number, use {@see #toString}.
+ * @return {number} Build number, as an integer.
+ */
+wtf.version.getBuild = function() {
+  // TODO(benvanik): get this from the current build date? or update-version.sh?
+  return 1355734800000;
+};
+
+
+/**
+ * Gets the version as a human-readable string that matches the version string
+ * used elsewhere, such as {@code 2012.12.12.2}.
+ * @return {string} Version string.
+ */
+wtf.version.toString = function() {
+  var dt = new Date(wtf.version.getBuild());
+  return dt.getFullYear() + '.' +
+      goog.string.padNumber(dt.getMonth() + 1, 2) + '.' +
+      goog.string.padNumber(dt.getDate(), 2) + '.' +
+      goog.string.padNumber(dt.getHours(), 1);
+};
+
+
+goog.exportSymbol(
+    'wtf.version.getBuild',
+    wtf.version.getBuild);
+goog.exportSymbol(
+    'wtf.version.toString',
+    wtf.version.toString);

--- a/src/wtf/wtf.js
+++ b/src/wtf/wtf.js
@@ -13,14 +13,8 @@
 
 goog.provide('wtf');
 
-
-/**
- * Version identifier.
- * TODO(benvanik): something sane
- * @const
- * @type {number}
- */
-wtf.VERSION = 1;
+/** @suppress {extraRequire} */
+goog.require('wtf.version');
 
 
 /**


### PR DESCRIPTION
Future pulls will update this value from a script.
Fixes #128.
