### PR TITLE
Using node-microtime for wtf.now if available.

### DIFF
--- a/scripts/run-benchmarks.sh
+++ b/scripts/run-benchmarks.sh
@@ -10,7 +10,7 @@
 
 
 # Fast build and ensure test dependencies exist.
-./third_party/anvil-build/anvil-local.sh build :debug :release
+./third_party/anvil-build/anvil-local.sh build :wtf_node_js_compiled
 
 
 GREP="$1"


### PR DESCRIPTION
This speeds up the benchmark form 0.00088ms/scope to 0.00033ms/scope.
