### PR TITLE
Adding a static wtf.trace.scopeLeave to make it easier to write custom

### DIFF
--- a/src/wtf/trace/exports.js
+++ b/src/wtf/trace/exports.js
@@ -105,6 +105,9 @@ if (wtf.trace.exports.ENABLE_EXPORTS) {
       'wtf.trace.enterTracingScope',
       wtf.trace.enterTracingScope);
   goog.exportSymbol(
+      'wtf.trace.leaveScope',
+      wtf.trace.leaveScope);
+  goog.exportSymbol(
       'wtf.trace.appendScopeData',
       wtf.trace.appendScopeData);
 

--- a/src/wtf/trace/trace.js
+++ b/src/wtf/trace/trace.js
@@ -370,6 +370,22 @@ wtf.trace.enterTracingScope = wtf.trace.BuiltinEvents.enterTracingScope;
 
 
 /**
+ * Leaves a scope.
+ * @param {wtf.trace.Scope} scope Scope to leave.
+ * @param {T=} opt_result Optional result to chain.
+ * @param {number=} opt_time Time for the leave; omit to use the current time.
+ * @return {T|undefined} The value of the {@code opt_result} parameter.
+ * @template T
+ */
+wtf.trace.leaveScope = function(scope, opt_result, opt_time) {
+  if (scope) {
+    scope.leave(opt_result, opt_time);
+  }
+  return opt_result;
+};
+
+
+/**
  * Appends a named argument of any type to the current scope.
  * This is slow and should only be used for very infrequent appends.
  * Prefer instead to use a custom instance event with the

--- a/wtf-trace-shim.js
+++ b/wtf-trace-shim.js
@@ -107,48 +107,8 @@ wtfapi.io.ByteArray;
 wtfapi.trace.Zone;
 
 
-
 /**
- * Dummy scope object.
- * Has the same exported methods as a real {@see wtfapi.trace.Scope}.
- * @constructor
- * @private
- */
-wtfapi.MockScope_ = function() {
-};
-
-
-/**
- * Leave mock.
- * @param {T=} opt_result Optional result to chain.
- * @return {T|undefined} The value of the {@code opt_result} parameter.
- * @template T
- */
-wtfapi.MockScope_.prototype['leave'] = function(opt_result) {
-  return opt_result;
-};
-
-
-/**
- * Dummy scope.
- * @type {!wtfapi.MockScope_}
- * @private
- */
-wtfapi.DUMMY_SCOPE_ = new wtfapi.MockScope_();
-
-
-/**
- * A function that returns the dummy scope.
- * @return {!wtfapi.MockScope_} Dummy scope.
- * @private
- */
-wtfapi.DUMMY_SCOPE_GENERATOR_ = function() {
-  return wtfapi.DUMMY_SCOPE_;
-};
-
-
-/**
- * @typedef {wtfapi.MockScope_}
+ * @typedef {Object}
  */
 wtfapi.trace.Scope;
 
@@ -233,11 +193,7 @@ wtfapi.trace.events.createInstance = wtfapi.PRESENT ?
  * @return {Function} New event type.
  */
 wtfapi.trace.events.createScope = wtfapi.PRESENT ?
-    goog.global['wtf']['trace']['events']['createScope'] : function() {
-      // Always return a dummy scope so that code calling scope.leave still
-      // works without a null check.
-      return wtfapi.DUMMY_SCOPE_GENERATOR_;
-    };
+    goog.global['wtf']['trace']['events']['createScope'] : goog.nullFunction;
 
 
 /**
@@ -284,13 +240,10 @@ wtfapi.trace.popZone = wtfapi.PRESENT ?
  * @param {wtfapi.trace.Flow=} opt_flow A flow to terminate on scope leave, if
  *     any.
  * @param {number=} opt_time Time for the enter; omit to use the current time.
- * @return {!wtfapi.trace.Scope} An initialized scope object.
+ * @return {wtfapi.trace.Scope} An initialized scope object.
  */
 wtfapi.trace.enterScope = wtfapi.PRESENT ?
-    goog.global['wtf']['trace']['enterScope'] :
-    function(opt_msg, opt_flow, opt_time) {
-      return wtfapi.DUMMY_SCOPE_;
-    };
+    goog.global['wtf']['trace']['enterScope'] : goog.nullFunction;
 
 
 /**
@@ -300,13 +253,22 @@ wtfapi.trace.enterScope = wtfapi.PRESENT ?
  * @param {wtfapi.trace.Flow=} opt_flow A flow to terminate on scope leave, if
  *     any.
  * @param {number=} opt_time Time for the enter; omit to use the current time.
- * @return {!wtfapi.trace.Scope} An initialized scope object.
+ * @return {wtfapi.trace.Scope} An initialized scope object.
  */
 wtfapi.trace.enterTracingScope = wtfapi.PRESENT ?
-    goog.global['wtf']['trace']['enterTracingScope'] :
-    function(opt_flow, opt_time) {
-      return wtfapi.DUMMY_SCOPE_;
-    };
+    goog.global['wtf']['trace']['enterTracingScope'] : goog.nullFunction;
+
+
+/**
+ * Leaves a scope.
+ * @param {wtf.trace.Scope} scope Scope to leave.
+ * @param {T=} opt_result Optional result to chain.
+ * @param {number=} opt_time Time for the leave; omit to use the current time.
+ * @return {T|undefined} The value of the {@code opt_result} parameter.
+ * @template T
+ */
+wtfapi.trace.leaveScope = wtfapi.PRESENT ?
+    goog.global['wtf']['trace']['leaveScope'] : goog.identityFunction;
 
 
 /**


### PR DESCRIPTION
scope management code.
This means that instead of if (!scope) { scope.leave(); } one can just
use wtf.trace.leaveScope(scope). This also helps the compiler by having
goog.nullFunction and goog.identityFunction used instead of custom mock
objects.
