### PR TITLE
Redoing how serialization/parsing works.

### DIFF
--- a/src/wtf/analysis/eventtypebuilder.js
+++ b/src/wtf/analysis/eventtypebuilder.js
@@ -13,6 +13,7 @@
 
 goog.provide('wtf.analysis.EventTypeBuilder');
 
+goog.require('goog.json');
 goog.require('wtf.io.Buffer');
 goog.require('wtf.util.FunctionBuilder');
 
@@ -46,6 +47,7 @@ goog.inherits(wtf.analysis.EventTypeBuilder, wtf.util.FunctionBuilder);
  *     class.
  */
 wtf.analysis.EventTypeBuilder.prototype.generate = function(eventType) {
+  var readers = wtf.analysis.EventTypeBuilder.READERS_;
   if (!wtf.util.FunctionBuilder.isSupported()) {
     // Fallback to non-codegen version.
     var args = eventType.args;
@@ -53,13 +55,14 @@ wtf.analysis.EventTypeBuilder.prototype.generate = function(eventType) {
       var value = {};
       for (var n = 0; n < args.length; n++) {
         var arg = args[n];
-        value[arg.name] = arg.read(buffer);
+        value[arg.name] = readers[arg.typeName].read(buffer);
       }
       return value;
     };
   }
 
   this.begin();
+  this.addScopeVariable('jsonParse', goog.json.parse);
   this.addArgument('buffer');
 
   // Storage for data.
@@ -69,11 +72,390 @@ wtf.analysis.EventTypeBuilder.prototype.generate = function(eventType) {
   // Parse data arguments.
   for (var n = 0; n < eventType.args.length; n++) {
     var arg = eventType.args[n];
-    var targetName = 'value["' + arg.name + '"]';
-    this.append(arg.getReadSource(this.bufferNames_, targetName) + ';');
+    var reader = readers[arg.typeName];
+    this.append.apply(this, reader.readSource(arg.name, this.bufferNames_));
   }
 
   this.append('return value;');
 
   return this.end(eventType.toString());
+};
+
+
+/**
+ * @typedef {{
+ *   read: function(!wtf.io.Buffer):(*),
+ *   readSource: function(string, !Object):(!Array.<string>)
+ * }}
+ * @private
+ */
+wtf.analysis.EventTypeBuilder.Reader_;
+
+
+/**
+ * @type {wtf.analysis.EventTypeBuilder.Reader_}
+ * @private
+ */
+wtf.analysis.EventTypeBuilder.READ_INT8_ = {
+  read: function(buffer) {
+    return buffer.readInt8();
+  },
+  readSource: function(a, bufferNames) {
+    return [
+      'value["' + a + '"] = buffer.' + bufferNames.readInt8 + '();'
+    ];
+  }
+};
+
+
+/**
+ * @type {wtf.analysis.EventTypeBuilder.Reader_}
+ * @private
+ */
+wtf.analysis.EventTypeBuilder.READ_INT8ARRAY_ = {
+  read: function(buffer) {
+    var length = buffer.readUint32();
+    var result = new Int8Array(length);
+    for (var n = 0; n < length; n++) {
+      result[n] = buffer.readInt8();
+    }
+    return result;
+  },
+  readSource: function(a, bufferNames) {
+    return [
+      // TODO(benvanik): optimize big array reads.
+      'var ' + a + '_len = buffer.' + bufferNames.readUint32 + '();',
+      'var ' + a + '_ = value["' + a + '"] = new Int8Array(' + a + '_len);',
+      'for (var n = 0; n < ' + a + '_len; n++) {',
+      '  ' + a + '_[n] = buffer.' + bufferNames.readInt8 + '();',
+      '}'
+    ];
+  }
+};
+
+
+/**
+ * @type {wtf.analysis.EventTypeBuilder.Reader_}
+ * @private
+ */
+wtf.analysis.EventTypeBuilder.READ_UINT8_ = {
+  read: function(buffer) {
+    return buffer.readUint8();
+  },
+  readSource: function(a, bufferNames) {
+    return [
+      'value["' + a + '"] = buffer.' + bufferNames.readUint8 + '();'
+    ];
+  }
+};
+
+
+/**
+ * @type {wtf.analysis.EventTypeBuilder.Reader_}
+ * @private
+ */
+wtf.analysis.EventTypeBuilder.READ_UINT8ARRAY_ = {
+  read: function(buffer) {
+    var length = buffer.readUint32();
+    var result = new Uint8Array(length);
+    for (var n = 0; n < length; n++) {
+      result[n] = buffer.readUint8();
+    }
+    return result;
+  },
+  readSource: function(a, bufferNames) {
+    return [
+      // TODO(benvanik): optimize big array reads.
+      'var ' + a + '_len = buffer.' + bufferNames.readUint32 + '();',
+      'var ' + a + '_ = value["' + a + '"] = new Uint8Array(' + a + '_len);',
+      'for (var n = 0; n < ' + a + '_len; n++) {',
+      '  ' + a + '_[n] = buffer.' + bufferNames.readUint8 + '();',
+      '}'
+    ];
+  }
+};
+
+
+/**
+ * @type {wtf.analysis.EventTypeBuilder.Reader_}
+ * @private
+ */
+wtf.analysis.EventTypeBuilder.READ_INT16_ = {
+  read: function(buffer) {
+    return buffer.readInt16();
+  },
+  readSource: function(a, bufferNames) {
+    return [
+      'value["' + a + '"] = buffer.' + bufferNames.readInt16 + '();'
+    ];
+  }
+};
+
+
+/**
+ * @type {wtf.analysis.EventTypeBuilder.Reader_}
+ * @private
+ */
+wtf.analysis.EventTypeBuilder.READ_INT16ARRAY_ = {
+  read: function(buffer) {
+    var length = buffer.readUint32();
+    var result = new Uint16Array(length);
+    for (var n = 0; n < length; n++) {
+      result[n] = buffer.readUint16();
+    }
+    return result;
+  },
+  readSource: function(a, bufferNames) {
+    return [
+      // TODO(benvanik): optimize big array reads.
+      'var ' + a + '_len = buffer.' + bufferNames.readUint32 + '();',
+      'var ' + a + '_ = value["' + a + '"] = new Int16Array(' + a + '_len);',
+      'for (var n = 0; n < ' + a + '_len; n++) {',
+      '  ' + a + '_[n] = buffer.' + bufferNames.readUint16 + '();',
+      '}'
+    ];
+  }
+};
+
+
+/**
+ * @type {wtf.analysis.EventTypeBuilder.Reader_}
+ * @private
+ */
+wtf.analysis.EventTypeBuilder.READ_UINT16_ = {
+  read: function(buffer) {
+    return buffer.readUint16();
+  },
+  readSource: function(a, bufferNames) {
+    return [
+      'value["' + a + '"] = buffer.' + bufferNames.readUint16 + '();'
+    ];
+  }
+};
+
+
+/**
+ * @type {wtf.analysis.EventTypeBuilder.Reader_}
+ * @private
+ */
+wtf.analysis.EventTypeBuilder.READ_UINT16ARRAY_ = {
+  read: function(buffer) {
+    var length = buffer.readUint32();
+    var result = new Uint16Array(length);
+    for (var n = 0; n < length; n++) {
+      result[n] = buffer.readUint16();
+    }
+    return result;
+  },
+  readSource: function(a, bufferNames) {
+    return [
+      // TODO(benvanik): optimize big array reads.
+      'var ' + a + '_len = buffer.' + bufferNames.readUint32 + '();',
+      'var ' + a + '_ = value["' + a + '"] = new Uint16Array(' + a + '_len);',
+      'for (var n = 0; n < ' + a + '_len; n++) {',
+      '  ' + a + '_[n] = buffer.' + bufferNames.readUint16 + '();',
+      '}'
+    ];
+  }
+};
+
+
+/**
+ * @type {wtf.analysis.EventTypeBuilder.Reader_}
+ * @private
+ */
+wtf.analysis.EventTypeBuilder.READ_INT32_ = {
+  read: function(buffer) {
+    return buffer.readInt32();
+  },
+  readSource: function(a, bufferNames) {
+    return [
+      'value["' + a + '"] = buffer.' + bufferNames.readInt32 + '();'
+    ];
+  }
+};
+
+
+/**
+ * @type {wtf.analysis.EventTypeBuilder.Reader_}
+ * @private
+ */
+wtf.analysis.EventTypeBuilder.READ_INT32ARRAY_ = {
+  read: function(buffer) {
+    var length = buffer.readUint32();
+    var result = new Int32Array(length);
+    for (var n = 0; n < length; n++) {
+      result[n] = buffer.readInt32();
+    }
+    return result;
+  },
+  readSource: function(a, bufferNames) {
+    return [
+      // TODO(benvanik): optimize big array reads.
+      'var ' + a + '_len = buffer.' + bufferNames.readUint32 + '();',
+      'var ' + a + '_ = value["' + a + '"] = new Int32Array(' + a + '_len);',
+      'for (var n = 0; n < ' + a + '_len; n++) {',
+      '  ' + a + '_[n] = buffer.' + bufferNames.readInt32 + '();',
+      '}'
+    ];
+  }
+};
+
+
+/**
+ * @type {wtf.analysis.EventTypeBuilder.Reader_}
+ * @private
+ */
+wtf.analysis.EventTypeBuilder.READ_UINT32_ = {
+  read: function(buffer) {
+    return buffer.readUint32();
+  },
+  readSource: function(a, bufferNames) {
+    return [
+      'value["' + a + '"] = buffer.' + bufferNames.readUint32 + '();'
+    ];
+  }
+};
+
+
+/**
+ * @type {wtf.analysis.EventTypeBuilder.Reader_}
+ * @private
+ */
+wtf.analysis.EventTypeBuilder.READ_UINT32ARRAY_ = {
+  read: function(buffer) {
+    var length = buffer.readUint32();
+    var result = new Uint32Array(length);
+    for (var n = 0; n < length; n++) {
+      result[n] = buffer.readUint32();
+    }
+    return result;
+  },
+  readSource: function(a, bufferNames) {
+    return [
+      // TODO(benvanik): optimize big array reads.
+      'var ' + a + '_len = buffer.' + bufferNames.readUint32 + '();',
+      'var ' + a + '_ = value["' + a + '"] = new Uint32Array(' + a + '_len);',
+      'for (var n = 0; n < ' + a + '_len; n++) {',
+      '  ' + a + '_[n] = buffer.' + bufferNames.readUint32 + '();',
+      '}'
+    ];
+  }
+};
+
+
+/**
+ * @type {wtf.analysis.EventTypeBuilder.Reader_}
+ * @private
+ */
+wtf.analysis.EventTypeBuilder.READ_FLOAT32_ = {
+  read: function(buffer) {
+    return buffer.readFloat32();
+  },
+  readSource: function(a, bufferNames) {
+    return [
+      'value["' + a + '"] = buffer.' + bufferNames.readFloat32 + '();'
+    ];
+  }
+};
+
+
+/**
+ * @type {wtf.analysis.EventTypeBuilder.Reader_}
+ * @private
+ */
+wtf.analysis.EventTypeBuilder.READ_FLOAT32ARRAY_ = {
+  read: function(buffer) {
+    var length = buffer.readUint32();
+    var result = new Float32Array(length);
+    for (var n = 0; n < length; n++) {
+      result[n] = buffer.readFloat32();
+    }
+    return result;
+  },
+  readSource: function(a, bufferNames) {
+    return [
+      // TODO(benvanik): optimize big array reads.
+      'var ' + a + '_len = buffer.' + bufferNames.readUint32 + '();',
+      'var ' + a + '_ = value["' + a + '"] = new Float32Array(' + a + '_len);',
+      'for (var n = 0; n < ' + a + '_len; n++) {',
+      '  ' + a + '_[n] = buffer.' + bufferNames.readFloat32 + '();',
+      '}'
+    ];
+  }
+};
+
+
+/**
+ * @type {wtf.analysis.EventTypeBuilder.Reader_}
+ * @private
+ */
+wtf.analysis.EventTypeBuilder.READ_ASCII_ = {
+  read: function(buffer) {
+    return buffer.readAsciiString();
+  },
+  readSource: function(a, bufferNames) {
+    return [
+      'value["' + a + '"] = buffer.' + bufferNames.readAsciiString + '();'
+    ];
+  }
+};
+
+
+/**
+ * @type {wtf.analysis.EventTypeBuilder.Reader_}
+ * @private
+ */
+wtf.analysis.EventTypeBuilder.READ_UTF8_ = {
+  read: function(buffer) {
+    return buffer.readUtf8String();
+  },
+  readSource: function(a, bufferNames) {
+    return [
+      'value["' + a + '"] = buffer.' + bufferNames.readUtf8String + '();'
+    ];
+  }
+};
+
+
+/**
+ * @type {wtf.analysis.EventTypeBuilder.Reader_}
+ * @private
+ */
+wtf.analysis.EventTypeBuilder.READ_ANY_ = {
+  read: function(buffer) {
+    return buffer.readInt8();
+  },
+  readSource: function(a, bufferNames) {
+    return [
+      'value["' + a + '"] = jsonParse(' +
+          'buffer.' + bufferNames.readUtf8String + '());'
+    ];
+  }
+};
+
+
+/**
+ * Reader information for supported types.
+ * @type {!Object.<!wtf.analysis.EventTypeBuilder.Reader_>}
+ * @private
+ */
+wtf.analysis.EventTypeBuilder.READERS_ = {
+  'int8': wtf.analysis.EventTypeBuilder.READ_INT8_,
+  'int8[]': wtf.analysis.EventTypeBuilder.READ_INT8ARRAY_,
+  'uint8': wtf.analysis.EventTypeBuilder.READ_UINT8_,
+  'uint8[]': wtf.analysis.EventTypeBuilder.READ_UINT8ARRAY_,
+  'int16': wtf.analysis.EventTypeBuilder.READ_INT16_,
+  'int16[]': wtf.analysis.EventTypeBuilder.READ_INT16ARRAY_,
+  'uint16': wtf.analysis.EventTypeBuilder.READ_UINT16_,
+  'uint16[]': wtf.analysis.EventTypeBuilder.READ_UINT16ARRAY_,
+  'int32': wtf.analysis.EventTypeBuilder.READ_INT32_,
+  'int32[]': wtf.analysis.EventTypeBuilder.READ_INT32ARRAY_,
+  'uint32': wtf.analysis.EventTypeBuilder.READ_UINT32_,
+  'uint32[]': wtf.analysis.EventTypeBuilder.READ_UINT32ARRAY_,
+  'float32': wtf.analysis.EventTypeBuilder.READ_FLOAT32_,
+  'float32[]': wtf.analysis.EventTypeBuilder.READ_FLOAT32ARRAY_,
+  'ascii': wtf.analysis.EventTypeBuilder.READ_ASCII_,
+  'utf8': wtf.analysis.EventTypeBuilder.READ_UTF8_,
+  'any': wtf.analysis.EventTypeBuilder.READ_ANY_
 };

--- a/src/wtf/analysis/scope.js
+++ b/src/wtf/analysis/scope.js
@@ -175,7 +175,7 @@ wtf.analysis.Scope.prototype.getData = function() {
       var e = this.dataEvents_[n];
       if (e.eventType.flags & wtf.data.EventFlag.INTERNAL) {
         // name-value pair from the builtin appending functions.
-        data[e.args['name']] = goog.global.JSON.parse(e.args['json']);
+        data[e.args['name']] = e.args['value'];
       } else {
         // Custom appender, use args.
         for (var m = 0; m < e.eventType.args.length; m++) {

--- a/src/wtf/app/ui/tracks/zonepainter.js
+++ b/src/wtf/app/ui/tracks/zonepainter.js
@@ -670,6 +670,21 @@ wtf.app.ui.tracks.ZonePainter.prototype.addArgumentLines_ = function(
     var argValue = data[argName];
     if (goog.isArray(argValue)) {
       argValue = '[' + argValue + ']';
+    } else if (argValue.buffer && argValue.buffer instanceof ArrayBuffer) {
+      // TODO(benvanik): better display of big data blobs.
+      var argString = '[';
+      var maxCount = 16;
+      for (var n = 0; n < Math.min(argValue.length, maxCount); n++) {
+        if (n) {
+          argString += ',';
+        }
+        argString += argValue[n];
+      }
+      if (argValue.length > maxCount) {
+        argString += ' ...';
+      }
+      argString += ']';
+      argValue = argString;
     } else if (goog.isObject(argValue)) {
       argValue = goog.global.JSON.stringify(argValue);
     }

--- a/src/wtf/trace/builtinevents.js
+++ b/src/wtf/trace/builtinevents.js
@@ -90,7 +90,7 @@ wtf.trace.BuiltinEvents = {
    * Appends data to the current scope.
    */
   appendScopeData: wtf.trace.events.createInstance(
-      'wtf.scope#appendData(ascii name, utf8 json)',
+      'wtf.scope#appendData(ascii name, any value)',
       wtf.data.EventFlag.BUILTIN | wtf.data.EventFlag.INTERNAL |
       wtf.data.EventFlag.APPEND_SCOPE_DATA),
 

--- a/src/wtf/trace/eventtype.js
+++ b/src/wtf/trace/eventtype.js
@@ -123,7 +123,7 @@ wtf.trace.EventType.prototype.getArgString = function() {
   var parts = [];
   for (var n = 0; n < this.args.length; n++) {
     var arg = this.args[n];
-    parts.push(arg.signatureName + ' ' + arg.name);
+    parts.push(arg.typeName + ' ' + arg.name);
   }
   return parts.join(', ');
 };

--- a/src/wtf/trace/eventtypebuilder.js
+++ b/src/wtf/trace/eventtypebuilder.js
@@ -13,9 +13,12 @@
 
 goog.provide('wtf.trace.EventTypeBuilder');
 
+goog.require('goog.asserts');
+goog.require('goog.json');
 goog.require('wtf');
 goog.require('wtf.data.EventClass');
 goog.require('wtf.io.Buffer');
+goog.require('wtf.io.floatConverter');
 goog.require('wtf.trace.EventType');
 goog.require('wtf.util.FunctionBuilder');
 
@@ -58,25 +61,61 @@ goog.inherits(wtf.trace.EventTypeBuilder, wtf.util.FunctionBuilder);
  */
 wtf.trace.EventTypeBuilder.prototype.generate = function(
     sessionPtr, eventType) {
+  var writers = wtf.trace.EventTypeBuilder.WRITERS_;
+
   // Begin building the function with default args.
   this.begin();
   this.addScopeVariable('sessionPtr', sessionPtr);
   this.addScopeVariable('eventType', eventType);
   this.addScopeVariable('now', wtf.now);
-
-  // Build a complete list of custom data arguments.
-  // Each variable maps to an argument to the function.
-  // Also calculate whether the size of the event is variable or not.
-  var args = eventType.args;
-  var minSize = 1 + 1 + 4;
-  var isVariableSize = false;
-  for (var n = 0; n < args.length; n++) {
-    var dataArg = args[n];
-    this.addArgument(dataArg.name + '_');
-    if (dataArg.isFixedSize) {
-      minSize += dataArg.getSize();
+  this.addScopeVariable('writeFloat32',
+      wtf.io.floatConverter.float32ToUint8Array);
+  this.addScopeVariable('stringify', function(value) {
+    // TODO(benvanik): make this even faster.
+    var json = null;
+    if (typeof value == 'number') {
+      json = '' + value;
+    } else if (typeof value == 'boolean') {
+      json = '' + value;
+    } else if (!value) {
+      json = null;
+    } else if (typeof value == 'string') {
+      // TODO(benvanik): escape the string (at least quotes).
+      json = '"' + value + '"';
     } else {
-      isVariableSize = true;
+      // JSON is faster and generates less garbage.
+      if (goog.global.JSON) {
+        json = goog.global.JSON.stringify(value);
+      } else {
+        json = goog.json.serialize(value);
+      }
+    }
+    return json;
+  });
+
+  // Count.
+  this.append('eventType.' + this.eventTypeNames_.count + '++;');
+
+  // Setup arguments.
+  // This adds arguments to the function and for any arguments that require
+  // preparation (variable length/encoded) this is done here to get their
+  // size.
+  var minSize = 2 + 4;
+  // TODO(benvanik): add support for extension data here
+  var args = eventType.args;
+  for (var n = 0; n < args.length; n++) {
+    var arg = args[n];
+    this.addArgument(arg.name + '_');
+    var writer = writers[arg.typeName];
+    goog.asserts.assert(writer);
+    minSize += writer.size; // 0 if variable sized
+  }
+  this.append('var size = ' + minSize + ';');
+  for (var n = 0; n < args.length; n++) {
+    var arg = args[n];
+    var writer = writers[arg.typeName];
+    if (writer.prepare) {
+      this.append.apply(this, writer.prepare(arg.name + '_'));
     }
   }
 
@@ -84,41 +123,14 @@ wtf.trace.EventTypeBuilder.prototype.generate = function(
   this.addArgument('opt_time');
   this.addArgument('opt_buffer');
 
+  this.append('var time = opt_time || now();');
+  this.append('var session = sessionPtr[0];');
+  this.append('var buffer = opt_buffer;');
   this.append(
-      'var session = sessionPtr[0];');
-  this.append(
-      'if (!session) { return undefined; }');
-
-  this.append(
-      'var time = opt_time || now();');
-
-  // Write buffer acquisition code (and size calculate if variable size).
-  if (!isVariableSize) {
-    // Size known - grab the buffer quickly.
-    this.append(
-        'var buffer = opt_buffer || session.acquireBuffer(' +
-        'time, ' + minSize + ');');
-  } else {
-    // Size unknown - compute size and grab the buffer.
-    this.append(
-        'var argSize = 0;');
-    for (var n = 0; n < args.length; n++) {
-      var dataArg = args[n];
-      if (!dataArg.isFixedSize) {
-        // Calculate variable size at runtime.
-        var sizeSource = dataArg.getSizeCalculationSource(dataArg.name + '_');
-        this.append(
-            'argSize += ' + sizeSource + ';');
-      }
-    }
-    this.append(
-        'var buffer = opt_buffer || session.acquireBuffer(' +
-        'time, ' + minSize + ' + argSize);');
-  }
-
-  // Early out if the buffer couldn't be acquired.
-  this.append(
-      'if (!buffer) { return undefined; }');
+      'if (!buffer && (!session || ' +
+      '!(buffer = session.acquireBuffer(time, size)))) {',
+      '  return undefined;',
+      '}');
 
   // Write event header.
   // This is manually inlined because it's so common and we don't get any
@@ -132,25 +144,24 @@ wtf.trace.EventTypeBuilder.prototype.generate = function(
       'd[o++] = (itime >> 24) & 0xFF;',
       'd[o++] = (itime >> 16) & 0xFF;',
       'd[o++] = (itime >> 8) & 0xFF;',
-      'd[o++] = itime & 0xFF;',
-      'buffer.' + this.bufferNames_.offset + ' = o;');
+      'd[o++] = itime & 0xFF;');
 
-  // Append data arguments.
-  for (var n = 0; n < args.length; n++) {
-    var dataArg = args[n];
-    this.append('/* arg ' + n + ': ' + dataArg.name + ' */');
-    this.append(
-        dataArg.getWriteSource(this.bufferNames_, dataArg.name + '_') + ';');
+  // Append arguments.
+  if (args.length) {
+    this.append('var t = 0;');
+    for (var n = 0; n < args.length; n++) {
+      var arg = args[n];
+      var writer = writers[arg.typeName];
+      this.append.apply(this, writer.write(arg.name + '_', this.bufferNames_));
+    }
   }
 
-  // Count.
-  this.append(
-      'eventType.' + this.eventTypeNames_.count + '++;');
+  // Stash back the buffer offset.
+  this.append('buffer.' + this.bufferNames_.offset + ' = o;');
 
   // Enter scope/flow/etc.
   if (eventType.eventClass == wtf.data.EventClass.SCOPE) {
-    this.append(
-        'return session.enterTypedScope(time);');
+    this.append('return session.enterTypedScope(time);');
   }
 
   // Save off the final function.
@@ -160,4 +171,307 @@ wtf.trace.EventTypeBuilder.prototype.generate = function(
   fn['eventType'] = eventType;
 
   return fn;
+};
+
+
+/**
+ * @typedef {{
+ *   size: number,
+ *   prepare: (function(string):(!Array.<string>))?,
+ *   write: function(string, !Object):(!Array.<string>)
+ * }}
+ * @private
+ */
+wtf.trace.EventTypeBuilder.Writer_;
+
+
+/**
+ * @type {wtf.trace.EventTypeBuilder.Writer_}
+ * @private
+ */
+wtf.trace.EventTypeBuilder.WRITE_INT8_ = {
+  size: 1,
+  prepare: null,
+  write: function(a, bufferNames) {
+    return [
+      'd[o++] = ' + a + ' & 0xFF;'
+    ];
+  }
+};
+
+
+/**
+ * @type {wtf.trace.EventTypeBuilder.Writer_}
+ * @private
+ */
+wtf.trace.EventTypeBuilder.WRITE_INT8ARRAY_ = {
+  size: 0,
+  prepare: function(a) {
+    return [
+      'size += ' + a + '.length;'
+    ];
+  },
+  write: function(a, bufferNames) {
+    return [
+      'if (' + a + ' && (t = ' + a + '.length)) {',
+      '  d[o++] = (t >> 24) & 0xFF;',
+      '  d[o++] = (t >> 16) & 0xFF;',
+      '  d[o++] = (t >> 8) & 0xFF;',
+      '  d[o++] = t & 0xFF;',
+      '  for (var n = 0; n < t; n++, o++) {',
+      '    d[o] = ' + a + '[n];',
+      '  }',
+      '} else {',
+      '  d[o++] = d[o++] = d[o++] = d[o++] = 0;',
+      '}'
+    ];
+  }
+};
+
+
+/**
+ * @type {wtf.trace.EventTypeBuilder.Writer_}
+ * @private
+ */
+wtf.trace.EventTypeBuilder.WRITE_INT16_ = {
+  size: 2,
+  prepare: null,
+  write: function(a, bufferNames) {
+    return [
+      'd[o++] = (' + a + ' >> 8) & 0xFF;',
+      'd[o++] = ' + a + ' & 0xFF;'
+    ];
+  }
+};
+
+
+/**
+ * @type {wtf.trace.EventTypeBuilder.Writer_}
+ * @private
+ */
+wtf.trace.EventTypeBuilder.WRITE_INT16ARRAY_ = {
+  size: 0,
+  prepare: function(a) {
+    return [
+      'size += ' + a + '.length * 2;'
+    ];
+  },
+  write: function(a, bufferNames) {
+    return [
+      'if (' + a + ' && (t = ' + a + '.length)) {',
+      '  d[o++] = (t >> 24) & 0xFF;',
+      '  d[o++] = (t >> 16) & 0xFF;',
+      '  d[o++] = (t >> 8) & 0xFF;',
+      '  d[o++] = t & 0xFF;',
+      '  for (var n = 0; n < t; n++, o += 2) {',
+      '    var v = ' + a + '[n];',
+      '    d[o] = (v >> 8) & 0xFF;',
+      '    d[o + 1] = v & 0xFF;',
+      '  }',
+      '} else {',
+      '  d[o++] = d[o++] = d[o++] = d[o++] = 0;',
+      '}'
+    ];
+  }
+};
+
+
+/**
+ * @type {wtf.trace.EventTypeBuilder.Writer_}
+ * @private
+ */
+wtf.trace.EventTypeBuilder.WRITE_INT32_ = {
+  size: 4,
+  prepare: null,
+  write: function(a, bufferNames) {
+    return [
+      'var ' + a + '_ = ' + a + ' >>> 0;',
+      'd[o++] = (' + a + '_ >> 24) & 0xFF;',
+      'd[o++] = (' + a + '_ >> 16) & 0xFF;',
+      'd[o++] = (' + a + '_ >> 8) & 0xFF;',
+      'd[o++] = ' + a + '_ & 0xFF;'
+    ];
+  }
+};
+
+
+/**
+ * @type {wtf.trace.EventTypeBuilder.Writer_}
+ * @private
+ */
+wtf.trace.EventTypeBuilder.WRITE_INT32ARRAY_ = {
+  size: 0,
+  prepare: function(a) {
+    return [
+      'size += ' + a + '.length * 4;'
+    ];
+  },
+  write: function(a, bufferNames) {
+    return [
+      'if (' + a + ' && (t = ' + a + '.length)) {',
+      '  d[o++] = (t >> 24) & 0xFF;',
+      '  d[o++] = (t >> 16) & 0xFF;',
+      '  d[o++] = (t >> 8) & 0xFF;',
+      '  d[o++] = t & 0xFF;',
+      '  for (var n = 0; n < t; n++, o += 4) {',
+      '    var v = ' + a + '[n] >>> 0;',
+      '    d[o] = (v >> 24) & 0xFF;',
+      '    d[o + 1] = (v >> 16) & 0xFF;',
+      '    d[o + 2] = (v >> 8) & 0xFF;',
+      '    d[o + 3] = v & 0xFF;',
+      '  }',
+      '} else {',
+      '  d[o++] = d[o++] = d[o++] = d[o++] = 0;',
+      '}'
+    ];
+  }
+};
+
+
+/**
+ * @type {wtf.trace.EventTypeBuilder.Writer_}
+ * @private
+ */
+wtf.trace.EventTypeBuilder.WRITE_FLOAT32_ = {
+  size: 4,
+  prepare: null,
+  write: function(a, bufferNames) {
+    return [
+      'writeFloat32(' + a + ', d, o); o += 4;'
+    ];
+  }
+};
+
+
+/**
+ * @type {wtf.trace.EventTypeBuilder.Writer_}
+ * @private
+ */
+wtf.trace.EventTypeBuilder.WRITE_FLOAT32ARRAY_ = {
+  size: 0,
+  prepare: function(a) {
+    return [
+      'size += ' + a + '.length * 4;'
+    ];
+  },
+  write: function(a, bufferNames) {
+    return [
+      'if (' + a + ' && (t = ' + a + '.length)) {',
+      '  d[o++] = (t >> 24) & 0xFF;',
+      '  d[o++] = (t >> 16) & 0xFF;',
+      '  d[o++] = (t >> 8) & 0xFF;',
+      '  d[o++] = t & 0xFF;',
+      '  for (var n = 0; n < t; n++, o += 4) {',
+      '    writeFloat32(' + a + '[n], d, o);',
+      '  }',
+      '} else {',
+      '  d[o++] = d[o++] = d[o++] = d[o++] = 0;',
+      '}'
+    ];
+  }
+};
+
+
+/**
+ * @type {wtf.trace.EventTypeBuilder.Writer_}
+ * @private
+ */
+wtf.trace.EventTypeBuilder.WRITE_ASCII_ = {
+  size: 0,
+  prepare: function(a) {
+    return [
+      'size += ' + a + ' ? (2 + ' + a + '.length) : 2;'
+    ];
+  },
+  write: function(a, bufferNames) {
+    return [
+      'if (' + a + ' && ' + a + '.length) {',
+      // TODO(benvanik): fix APIs to prevent flush.
+      '  buffer.' + bufferNames.offset + ' = o;',
+      '  buffer.' + bufferNames.writeAsciiString + '(' + a + ');',
+      '  o = buffer.' + bufferNames.offset + ';',
+      '} else {',
+      '  d[o++] = d[o++] = 0;',
+      '}'
+    ];
+  }
+};
+
+
+/**
+ * @type {wtf.trace.EventTypeBuilder.Writer_}
+ * @private
+ */
+wtf.trace.EventTypeBuilder.WRITE_UTF8_ = {
+  size: 0,
+  prepare: function(a) {
+    return [
+      'size += ' + a + ' ? (2 + 2 + ' + a + '.length * 3) : 2;'
+    ];
+  },
+  write: function(a, bufferNames) {
+    return [
+      'if (' + a + ' && ' + a + '.length) {',
+      // TODO(benvanik): fix APIs to prevent flush.
+      '  buffer.' + bufferNames.offset + ' = o;',
+      '  buffer.' + bufferNames.writeUtf8String + '(' + a + ');',
+      '  o = buffer.' + bufferNames.offset + ';',
+      '} else {',
+      '  d[o++] = d[o++] = 0;',
+      '}'
+    ];
+  }
+};
+
+
+/**
+ * @type {wtf.trace.EventTypeBuilder.Writer_}
+ * @private
+ */
+wtf.trace.EventTypeBuilder.WRITE_ANY_ = {
+  size: 0,
+  prepare: function(a) {
+    return [
+      'var ' + a + '_ = stringify(' + a + ');',
+      'size += ' + a + '_ ? (2 + 2 + ' + a + '_.length * 3) : 2;'
+    ];
+  },
+  write: function(a, bufferNames) {
+    return [
+      'if (' + a + '_ && ' + a + '_.length) {',
+      // TODO(benvanik): fix APIs to prevent flush.
+      '  buffer.' + bufferNames.offset + ' = o;',
+      '  buffer.' + bufferNames.writeUtf8String + '(' + a + '_);',
+      '  o = buffer.' + bufferNames.offset + ';',
+      '} else {',
+      '  d[o++] = d[o++] = 0;',
+      '}'
+    ];
+  }
+};
+
+
+/**
+ * Writer information for supported types.
+ * @type {!Object.<!wtf.trace.EventTypeBuilder.Writer_>}
+ * @private
+ */
+wtf.trace.EventTypeBuilder.WRITERS_ = {
+  'int8': wtf.trace.EventTypeBuilder.WRITE_INT8_,
+  'int8[]': wtf.trace.EventTypeBuilder.WRITE_INT8ARRAY_,
+  'uint8': wtf.trace.EventTypeBuilder.WRITE_INT8_,
+  'uint8[]': wtf.trace.EventTypeBuilder.WRITE_INT8ARRAY_,
+  'int16': wtf.trace.EventTypeBuilder.WRITE_INT16_,
+  'int16[]': wtf.trace.EventTypeBuilder.WRITE_INT16ARRAY_,
+  'uint16': wtf.trace.EventTypeBuilder.WRITE_INT16_,
+  'uint16[]': wtf.trace.EventTypeBuilder.WRITE_INT16ARRAY_,
+  'int32': wtf.trace.EventTypeBuilder.WRITE_INT32_,
+  'int32[]': wtf.trace.EventTypeBuilder.WRITE_INT32ARRAY_,
+  'uint32': wtf.trace.EventTypeBuilder.WRITE_INT32_,
+  'uint32[]': wtf.trace.EventTypeBuilder.WRITE_INT32ARRAY_,
+  'float32': wtf.trace.EventTypeBuilder.WRITE_FLOAT32_,
+  'float32[]': wtf.trace.EventTypeBuilder.WRITE_FLOAT32ARRAY_,
+  'ascii': wtf.trace.EventTypeBuilder.WRITE_ASCII_,
+  'utf8': wtf.trace.EventTypeBuilder.WRITE_UTF8_,
+  'any': wtf.trace.EventTypeBuilder.WRITE_ANY_
 };

--- a/src/wtf/trace/providers/domprovider.js
+++ b/src/wtf/trace/providers/domprovider.js
@@ -506,7 +506,8 @@ wtf.trace.providers.DomProvider.InstrumentedType.prototype.hookObjectEvents =
     if (!goog.string.startsWith(this.name_, 'HTML')) {
       goog.global[this.name_] = function() {
         var result = new originalCtor();
-        // Delete the original keys (defineProperty does not allow redefinition).
+        // Delete the original keys (defineProperty does not allow
+        // redefinition).
         for (var n = 0; n < eventInfos.length; n++) {
           delete result[eventInfos[n].name];
         }

--- a/src/wtf/trace/providers/extendedinfoprovider.js
+++ b/src/wtf/trace/providers/extendedinfoprovider.js
@@ -100,6 +100,6 @@ wtf.trace.providers.ExtendedInfoProvider.prototype.traceGc_ = function(data) {
   var endTime = data['endTime'] - timebase;
   var usedHeapSize = data['usedHeapSize'];
   var usedHeapSizeDelta = data['usedHeapSizeDelta'];
-  var scope = this.events_.gc(usedHeapSize, usedHeapSizeDelta, null, startTime);
+  var scope = this.events_.gc(usedHeapSize, usedHeapSizeDelta, startTime);
   wtf.trace.leaveScope(scope, undefined, endTime);
 };

--- a/src/wtf/trace/trace.js
+++ b/src/wtf/trace/trace.js
@@ -16,7 +16,6 @@
 goog.provide('wtf.trace');
 
 goog.require('goog.asserts');
-goog.require('goog.json');
 goog.require('goog.string');
 goog.require('wtf.io.BufferedHttpWriteStream');
 goog.require('wtf.io.CustomWriteStream');
@@ -388,27 +387,7 @@ wtf.trace.leaveScope = wtf.trace.Scope.leave;
  * @param {*} value Value. Will be JSON stringified.
  * @param {number=} opt_time Time for the enter; omit to use the current time.
  */
-wtf.trace.appendScopeData = function(name, value, opt_time) {
-  // TODO(benvanik): make this even faster.
-  var json = null;
-  if (typeof value == 'number') {
-    json = '' + value;
-  } else if (typeof value == 'boolean') {
-    json = '' + value;
-  } else if (!value) {
-    json = null;
-  } else if (typeof value == 'string') {
-    json = '"' + value + '"';
-  } else {
-    // JSON is faster and generates less garbage.
-    if (goog.global.JSON) {
-      json = goog.global.JSON.stringify(value);
-    } else {
-      json = goog.json.serialize(value);
-    }
-  }
-  wtf.trace.BuiltinEvents.appendScopeData(name, json, opt_time);
-};
+wtf.trace.appendScopeData = wtf.trace.BuiltinEvents.appendScopeData;
 
 
 /**

--- a/src/wtf/util/functionbuilder.js
+++ b/src/wtf/util/functionbuilder.js
@@ -150,18 +150,19 @@ wtf.util.FunctionBuilder.prototype.end = function(name) {
   var combinedSource = this.currentSource_.join('\n');
 
   // Build closure wrapper.
+  var sourceUrl = name.replace(/#/g, '/');
   var creator = new Function(this.currentScopeVariableNames_, [
     '"use strict";',
     'return function(' + this.currentArgs_.join(', ') + ') {',
     combinedSource,
-    '};'
+    '};',
+    '//@ sourceURL=x://wtf/' + sourceUrl
   ].join('\n'));
+  creator['displayName'] = name;
 
   // Build function.
   var fn = creator.apply(null, this.currentScopeVariableValues_);
-  if (goog.DEBUG) {
-    fn['displayName'] = name;
-  }
+  fn['displayName'] = name;
 
   // Reset state.
   this.currentScopeVariableNames_.length = 0;

--- a/test/test-uncompiled.html
+++ b/test/test-uncompiled.html
@@ -34,6 +34,7 @@
   <div style="height: 2000px"></div>
   <script>
     window.onload = function() {
+      var arrayEvent = wtf.trace.events.createInstance('arrayEvent(uint8[] v)');
       var someLink = document.getElementById('someLink');
       someLink.addEventListener('click', function(e) {
         e.preventDefault();
@@ -42,6 +43,8 @@
         var scope = wtf.trace.enterScope('onclick');
 
         wtf.trace.appendScopeData('hello', 'world');
+
+        arrayEvent(new Uint8Array([1, 2, 3]));
 
         // Start flow...
         var flow = wtf.trace.branchFlow('click');

--- a/wtf-trace-shim.js
+++ b/wtf-trace-shim.js
@@ -327,7 +327,7 @@ wtfapi.trace.clearFlow = wtfapi.PRESENT ?
 /**
  * Spans the flow across processes.
  * Flows must have been branched before this can be used.
- * @param {!wtfapi.io.ByteArray} flowId Flow ID.
+ * @param {number} flowId Flow ID.
  * @return {!wtfapi.trace.Flow} An initialized flow object.
  */
 wtfapi.trace.spanFlow = wtfapi.PRESENT ?


### PR DESCRIPTION
This moves the read/write code closer to where its used - having it shared
made it more difficult to version (in the future) and the use of
caller-specific names was odd. Most writers have been inlined and readers
now properly create typed arrays.

Added the 'any' type that does the JSON conversion automatically. Custom
types can now use this. Helps support #149.

FunctionBuilder now puts a sourceURL in the functions making them show up
as 'wtf' in the dev tools.
