### PR TITLE
Adding app extensions/panels and a test one that draws a sankey diagram.

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -25,12 +25,8 @@ between tracing and apps.
       },
       "app": { // only include if needed
         "scripts": [
-          // Scripts that are inserted into the iframe, in order
+          // Scripts that are inserted into a hidden iframe, in order
           "some/file.js"
-        ],
-        "stylesheets": [
-          // Stylesheets inserted into the iframe, in order
-          "some/file.css"
         ],
         "triggers": [
           {
@@ -130,4 +126,47 @@ on it.
 
 ## App Extensions
 
-TODO(benvanik): implement and describe app extensions
+Application extensions run inside a hidden iframe sandbox inside of the
+application. Each extension gets loaded when a document is opened and destroyed
+when it is closed.
+
+Extensions have access to the `wtf.analysis` namespace on the global object as
+well as a few helper libraries, such as [d3](http://d3js.org/). Any other
+scripts can be inserted via the manifest.
+
+### documentView
+
+A global object `documentView` is available that contains APIs related to the
+currently loaded document.
+
+    // The wtf.analysis.db.EventDatabase instance of the document view.
+    documentView.db;
+
+### Panels
+
+Extensions can add any number of panels to the tab bar in the UI. Panels
+have their own iframes and can contain any content, such as custom scripts
+or stylesheets.
+
+    documentView.createTabPanel('mypanel', 'My Panel', {
+      // Stylesheets to add to the iframe, if any.
+      stylesheets: ['some.css'],
+      // Scripts to add to the document, if any.
+      scripts: ['some.js']
+    }, function(document) {
+      // Called back when the tab is created. 'document' is the iframe document.
+
+      // Setup a UI (or use a script).
+      var el = document.createElement('div');
+      document.body.appendChild(el);
+
+      // Optionally return some handlers for some events.
+      return {
+        onLayout: function(width, height) {
+          // Called if the tab is resized with the new width/height.
+        },
+        onVisbilityChange: function(visible) {
+          // Called when the tab is shown/hidden.
+        }
+      };
+    });

--- a/extensions/diagrams/diagrams-app.css
+++ b/extensions/diagrams/diagrams-app.css
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2012 Google, Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+/**
+ * Styles for the diagram extension.
+ *
+ * @author benvanik@google.com (Ben Vanik)
+ */
+
+.panelRoot {
+}
+
+svg {
+  font: 10px sans-serif;
+}
+
+.axis path, .axis line {
+  fill: none;
+  stroke: #000;
+  shape-rendering: crispEdges;
+}
+
+.node rect {
+  cursor: move;
+  fill-opacity: .9;
+  shape-rendering: crispEdges;
+}
+
+.node text {
+  pointer-events: none;
+  text-shadow: 0 1px 0 #fff;
+}
+
+.link {
+  fill: none;
+  stroke: #000;
+  stroke-opacity: .2;
+}
+
+.link:hover {
+  stroke-opacity: .5;
+}

--- a/extensions/diagrams/diagrams-app.js
+++ b/extensions/diagrams/diagrams-app.js
@@ -1,0 +1,215 @@
+/**
+ * Copyright 2012 Google, Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+/**
+ * @fileoverview Diagrams extension app code.
+ *
+ * @author benvanik@google.com (Ben Vanik)
+ */
+
+(function() {
+
+documentView.createTabPanel('diagrams', 'Diagrams', {
+  stylesheets: ['diagrams-app.css'],
+  scripts: []
+}, function(document) {
+  var el = document.createElement('div');
+  el.className = 'panelRoot';
+  document.body.appendChild(el);
+
+  var db = documentView.db;
+
+  var sankeyEl = document.createElement('div');
+  setupSankeyDiagram(sankeyEl, db);
+  el.appendChild(sankeyEl);
+
+  return {
+    onLayout: function(width, height) {
+      //console.log('onLayout ' + width + ', ' + height);
+    },
+    onVisibilityChange: function(value) {
+      //console.log('onVisibilityChange ' + value);
+    },
+  };
+});
+
+function computeScopeGraph(db, zoneIndex) {
+  // Edges in the graph, keyed by 'eventName|eventName', value is sum user time.
+  var edges = {};
+  var nodeList = [];
+  var nodeIndices = {};
+
+  nodeList.push({
+    name: '<root>',
+    eventType: null
+  });
+  nodeIndices['<root>'] = 0;
+
+  zoneIndex.forEach(Number.MIN_VALUE, Number.MAX_VALUE, function(e) {
+    var eventType = e.eventType;
+    if (eventType.eventClass == wtf.data.EventClass.SCOPE &&
+        !(eventType.flags & wtf.data.EventFlag.INTERNAL)) {
+      var scope = e.scope;
+      if (!nodeIndices[eventType.name]) {
+        nodeIndices[eventType.name] = nodeList.length;
+        nodeList.push({
+          name: eventType.name,
+          eventType: eventType
+        });
+      }
+
+      var key;
+      var parentScope = scope.getParent();
+      if (parentScope) {
+        // Child.
+        var parentEventType = parentScope.getEnterEvent().eventType;
+        if (!nodeIndices[parentEventType.name]) {
+          nodeIndices[parentEventType.name] = nodeList.length;
+          nodeList.push({
+            name: parentEventType.name,
+            eventType: parentEventType
+          });
+        }
+        key = parentEventType.name + '|' + eventType.name;
+      } else {
+        // Root scope.
+        key = '<root>|' + eventType.name;
+      }
+
+      var value = edges[key] || 0;
+      value += scope.getUserDuration();
+      edges[key] = value;
+    }
+  });
+
+  var edgeList = [];
+  for (var key in edges) {
+    var value = edges[key];
+    if (!value) {
+      continue;
+    }
+    var keyParts = key.split('|');
+    var parentName = keyParts[0];
+    var childName = keyParts[1];
+    if (parentName == childName) {
+      continue;
+    }
+    if (parentName == '<root>') {
+      continue;
+    }
+    edgeList.push({
+      source: nodeIndices[parentName],
+      target: nodeIndices[childName],
+      value: edges[key]
+    });
+  }
+
+  return {
+    nodes: nodeList,
+    edges: edgeList
+  };
+};
+
+function trimGraphCycles(graph) {
+  // Prevent cycles here - sankey.js doesn't support them yet.
+};
+
+function setupSankeyDiagram(el, db) {
+  var nodes = [];
+  var links = [];
+
+  var table = new wtf.analysis.db.EventDataTable(db);
+  var scopeTypes = table.getEntriesByClass(wtf.data.EventClass.SCOPE);
+
+  var zoneIndices = db.getZoneIndices();
+  for (var n = 0; n < zoneIndices.length; n++) {
+    var graph = computeScopeGraph(db, zoneIndices[n]);
+    trimGraphCycles(graph);
+    nodes = graph.nodes;
+    links = graph.edges;
+  }
+
+  var margin = {
+    top: 1,
+    right: 1,
+    bottom: 6,
+    left: 1
+  };
+  var width = 7000 - margin.left - margin.right;
+  var height = 7000 - margin.top - margin.bottom;
+
+  var formatNumber = d3.format(',.0f'),
+      format = function(d) { return formatNumber(d) + 'ms'; },
+      color = d3.scale.category20();
+
+  var svg = d3.select(el).append('svg')
+      .attr('width', width + margin.left + margin.right)
+      .attr('height', height + margin.top + margin.bottom)
+    .append('g')
+      .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
+
+  var sankey = d3.sankey()
+      .nodeWidth(15)
+      .nodePadding(10)
+      .size([width, height]);
+
+  var path = sankey.link();
+
+  sankey
+      .nodes(nodes)
+      .links(links)
+      .layout(1000);
+
+  var link = svg.append('g').selectAll('.link')
+      .data(links)
+    .enter().append('path')
+      .attr('class', 'link')
+      .attr('d', path)
+      .style('stroke-width', function(d) { return Math.max(1, d.dy); })
+      .sort(function(a, b) { return b.dy - a.dy; });
+
+  link.append('title')
+      .text(function(d) { return d.source.name + ' → ' + d.target.name + '\n' + format(d.value); });
+
+  var node = svg.append('g').selectAll('.node')
+      .data(nodes)
+    .enter().append('g')
+      .attr('class', 'node')
+      .attr('transform', function(d) { return 'translate(' + d.x + ',' + d.y + ')'; })
+    .call(d3.behavior.drag()
+      .origin(function(d) { return d; })
+      .on('dragstart', function() { this.parentNode.appendChild(this); })
+      .on('drag', dragmove));
+
+  node.append('rect')
+      .attr('height', function(d) { return d.dy; })
+      .attr('width', sankey.nodeWidth())
+      .style('fill', function(d) { return d.color = color(d.name.replace(/ .*/, '')); })
+      .style('stroke', function(d) { return d3.rgb(d.color).darker(2); })
+    .append('title')
+      .text(function(d) { return d.name + '\n' + format(d.value); });
+
+  node.append('text')
+      .attr('x', -6)
+      .attr('y', function(d) { return d.dy / 2; })
+      .attr('dy', '.35em')
+      .attr('text-anchor', 'end')
+      .attr('transform', null)
+      .text(function(d) { return d.name; })
+    .filter(function(d) { return d.x < width / 2; })
+      .attr('x', 6 + sankey.nodeWidth())
+      .attr('text-anchor', 'start');
+
+  function dragmove(d) {
+    var ey = d3.event.sourceEvent.pageY;
+    d3.select(this).attr('transform', 'translate(' + d.x + ',' + (d.y = Math.max(0, Math.min(height - d.dy, ey))) + ')');
+    sankey.relayout();
+    link.attr('d', path);
+  }
+}
+
+})();

--- a/extensions/diagrams/diagrams.json
+++ b/extensions/diagrams/diagrams.json
@@ -1,0 +1,11 @@
+{
+  "name": "Diagrams",
+  "required_version": "1.0.5",
+  "app": {
+    "scripts": [
+      "diagrams-app.js"
+    ],
+    "stylesheets": [
+    ]
+  }
+}

--- a/extensions/webglcapture/webglcapture-trace.js
+++ b/extensions/webglcapture/webglcapture-trace.js
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2012 Google, Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+/**
+ * @fileoverview WebGL Capture extension tracing code.
+ *
+ * @author benvanik@google.com (Ben Vanik)
+ */
+
 (function() {
 
 // Add a HUD button:

--- a/src/wtf/analysis/db/eventdatatable.js
+++ b/src/wtf/analysis/db/eventdatatable.js
@@ -300,6 +300,9 @@ goog.exportProperty(
     wtf.analysis.db.EventDataTable.prototype, 'getEventTypeEntry',
     wtf.analysis.db.EventDataTable.prototype.getEventTypeEntry);
 goog.exportProperty(
+    wtf.analysis.db.EventDataTable.prototype, 'getEntriesByClass',
+    wtf.analysis.db.EventDataTable.prototype.getEntriesByClass);
+goog.exportProperty(
     wtf.analysis.db.EventDataTable.prototype, 'forEach',
     wtf.analysis.db.EventDataTable.prototype.forEach);
 goog.exportSymbol(

--- a/src/wtf/analysis/sources/binarytracesource.js
+++ b/src/wtf/analysis/sources/binarytracesource.js
@@ -26,6 +26,7 @@ goog.require('wtf.analysis.ZoneEvent');
 goog.require('wtf.data.ContextInfo');
 goog.require('wtf.data.EventClass');
 goog.require('wtf.data.EventFlag');
+goog.require('wtf.data.Variable');
 goog.require('wtf.data.formats.BinaryTrace');
 goog.require('wtf.data.formats.FileFlags');
 goog.require('wtf.io.EventType');

--- a/src/wtf/app/ui/documentview.js
+++ b/src/wtf/app/ui/documentview.js
@@ -19,6 +19,7 @@ goog.require('goog.soy');
 goog.require('goog.style');
 goog.require('wtf.analysis.db.EventDatabase');
 goog.require('wtf.app.ui.EmptyTabPanel');
+goog.require('wtf.app.ui.ExtensionManager');
 goog.require('wtf.app.ui.Selection');
 goog.require('wtf.app.ui.Statusbar');
 goog.require('wtf.app.ui.Tabbar');
@@ -115,6 +116,14 @@ wtf.app.ui.DocumentView = function(parentElement, dom, doc) {
       goog.getCssName('wtfAppUiDocumentViewStatusbar')));
   this.registerDisposable(this.statusbar_);
 
+  /**
+   * Extension manager.
+   * @type {!wtf.app.ui.ExtensionManager}
+   * @private
+   */
+  this.extensionManager_ = new wtf.app.ui.ExtensionManager(this);
+  this.registerDisposable(this.extensionManager_);
+
   // Relayout as required.
   var vsm = goog.dom.ViewportSizeMonitor.getInstanceForWindow();
   this.getHandler().listen(vsm, goog.events.EventType.RESIZE, function() {
@@ -127,10 +136,6 @@ wtf.app.ui.DocumentView = function(parentElement, dom, doc) {
   this.tabbar_.addPanel(new wtf.app.ui.tracks.TracksPanel(this));
   this.tabbar_.addPanel(new wtf.app.ui.EmptyTabPanel(
       this, 'console', 'Console'));
-  this.tabbar_.addPanel(new wtf.app.ui.EmptyTabPanel(
-      this, 'something', 'Something'));
-  this.tabbar_.addPanel(new wtf.app.ui.EmptyTabPanel(
-      this, 'mumble', 'Mumble'));
 
   var keyboard = wtf.events.getWindowKeyboard(dom);
   var keyboardScope = new wtf.events.KeyboardScope(keyboard);
@@ -207,6 +212,15 @@ wtf.app.ui.DocumentView.prototype.getLocalView = function() {
  */
 wtf.app.ui.DocumentView.prototype.getSelection = function() {
   return this.selection_;
+};
+
+
+/**
+ * Gets the tab bar.
+ * @return {!wtf.app.ui.Tabbar} Tab bar.
+ */
+wtf.app.ui.DocumentView.prototype.getTabbar = function() {
+  return this.tabbar_;
 };
 
 

--- a/src/wtf/app/ui/extensionmanager.js
+++ b/src/wtf/app/ui/extensionmanager.js
@@ -1,0 +1,343 @@
+/**
+ * Copyright 2012 Google, Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+/**
+ * @fileoverview Application extension manager.
+ *
+ * @author benvanik@google.com (Ben Vanik)
+ */
+
+goog.provide('wtf.app.ui.ExtensionManager');
+goog.provide('wtf.app.ui.ExtensionTabPanel');
+
+goog.require('goog.Disposable');
+goog.require('goog.Uri');
+goog.require('goog.asserts');
+goog.require('goog.dom');
+goog.require('goog.dom.TagName');
+goog.require('goog.dom.classes');
+goog.require('goog.style');
+goog.require('wtf.app.ui.TabPanel');
+goog.require('wtf.ext');
+goog.require('wtf.timing');
+
+
+
+/**
+ * Handles the creation and management of app extensions.
+ * Since extensions are {@see wtf.app.ui.DocumentView}-specific, this ties
+ * extension lifetime to the parent document view.
+ *
+ * @param {!wtf.app.ui.DocumentView} documentView Parent document view.
+ * @constructor
+ * @extends {goog.Disposable}
+ */
+wtf.app.ui.ExtensionManager = function(documentView) {
+  goog.base(this);
+
+  var dom = documentView.getDom();
+
+  /**
+   * Parent document view.
+   * @type {!wtf.app.ui.DocumentView}
+   * @private
+   */
+  this.documentView_ = documentView;
+
+  /**
+   * DOM helper.
+   * @type {!goog.dom.DomHelper}
+   * @private
+   */
+  this.dom_ = dom;
+
+  /**
+   * Root element that gets the extension iframes added inside it.
+   * This makes it easier to clean them up and debug.
+   * @type {!Element}
+   * @private
+   */
+  this.extensionsEl_ = dom.createElement(goog.dom.TagName.DIV);
+  this.extensionsEl_.id = 'wtfAppExtensions';
+  dom.getDocument().body.appendChild(this.extensionsEl_);
+
+  /**
+   * All loaded extensions.
+   * @type {!Array.<{
+   *   extension: !wtf.ext.AppExtension,
+   *   iframe: !HTMLIFrameElement
+   * }>}
+   * @private
+   */
+  this.extensions_ = [];
+
+  /**
+   * Simple map of whether an extension has been loaded.
+   * @type {!Object.<boolean>}
+   * @private
+   */
+  this.loadedExtensions_ = {};
+
+  // Defer a bit to ensure everything gets created.
+  wtf.timing.setImmediate(function() {
+    var extensions = wtf.ext.getAppExtensions();
+    for (var n = 0; n < extensions.length; n++) {
+      // TODO(benvanik): only load if no triggers? setup delayed loading for
+      //     ones with triggers?
+      this.loadExtension(extensions[n]);
+    }
+  }, this);
+};
+goog.inherits(wtf.app.ui.ExtensionManager, goog.Disposable);
+
+
+/**
+ * @override
+ */
+wtf.app.ui.ExtensionManager.prototype.disposeInternal = function() {
+  goog.dom.removeNode(this.extensionsEl_);
+  goog.base(this, 'disposeInternal');
+};
+
+
+/**
+ * Loads the given extension, if it has not already been loaded.
+ * @param {!wtf.ext.AppExtension} extension Extension.
+ */
+wtf.app.ui.ExtensionManager.prototype.loadExtension = function(extension) {
+  var dom = this.dom_;
+
+  var manifest = extension.getManifest();
+  var info = extension.getInfo();
+
+  // Loaded check.
+  if (this.loadedExtensions_[manifest.getUrl()]) {
+    return;
+  }
+  this.loadedExtensions_[manifest.getUrl()] = true;
+
+  // Create iframe container.
+  var iframe = /** @type {!HTMLIFrameElement} */ (
+      dom.createElement(goog.dom.TagName.IFRAME));
+  this.extensionsEl_.appendChild(iframe);
+
+  // Set base.
+  var idoc = iframe.contentDocument;
+  var baseUri = goog.Uri.resolve(window.location.href, manifest.getUrl());
+  var baseEl = idoc.createElement(goog.dom.TagName.BASE);
+  baseEl.href = baseUri.toString();
+  idoc.head.appendChild(baseEl);
+
+  // Export API.
+  this.setupExtensionApi_(extension, iframe.contentWindow);
+
+  // Add scripts.
+  for (var n = 0; n < info.scripts.length; n++) {
+    var script = idoc.createElement(goog.dom.TagName.SCRIPT);
+    script.src = info.scripts[n];
+    idoc.body.appendChild(script);
+  }
+
+  this.extensions_.push({
+    extension: extension,
+    iframe: iframe
+  });
+};
+
+
+/**
+ * Sets up the extension API in the extension window.
+ * @param {!wtf.ext.AppExtension} extension Owning extension.
+ * @param {!Object} extensionGlobal Extension global scope.
+ * @private
+ */
+wtf.app.ui.ExtensionManager.prototype.setupExtensionApi_ = function(
+    extension, extensionGlobal) {
+  var documentView = this.documentView_;
+
+  extensionGlobal['wtf'] = goog.global['wtf'];
+  extensionGlobal['d3'] = goog.global['d3'];
+  extensionGlobal['documentView'] = {
+    'db': documentView.getDatabase(),
+    'createTabPanel': createTabPanel
+  };
+
+  var tabbar = documentView.getTabbar();
+  /**
+   * Creates a new tab panel.
+   * Part of the app extension API.
+   * @param {string} path Path used for navigation.
+   * @param {string} name Panel name.
+   * @param {Object} options Options.
+   * @param {wtf.app.ui.ExtensionTabPanel.Callback} callback
+   *     A callback that creates an external panel.
+   */
+  function createTabPanel(path, name, options, callback) {
+    tabbar.addPanel(new wtf.app.ui.ExtensionTabPanel(
+        extension, documentView, path, name, options, callback));
+  };
+};
+
+
+
+/**
+ * A tab panel that defers logic to an external extension.
+ * @param {!wtf.ext.AppExtension} extension Owning extension.
+ * @param {!wtf.app.ui.DocumentView} documentView Parent document view.
+ * @param {string} path Path used for navigation.
+ * @param {string} name Panel name.
+ * @param {Object} options Options.
+ * @param {wtf.app.ui.ExtensionTabPanel.Callback} callback
+ *     A callback that creates an external panel.
+ * @constructor
+ * @extends {wtf.app.ui.TabPanel}
+ */
+wtf.app.ui.ExtensionTabPanel = function(extension, documentView, path, name,
+    options, callback) {
+  goog.base(this, documentView, path, name);
+
+  /**
+   * Owning extension.
+   * @type {!wtf.ext.AppExtension}
+   * @private
+   */
+  this.extension_ = extension;
+
+  /**
+   * Tab panel options.
+   * @type {!Object}
+   * @private
+   */
+  this.options_ = options || {};
+
+  /**
+   * Panel contents iframe.
+   * Setup on a delay so that the panel has time to be added to the DOM
+   * for a tick so the iframe can be added and usable immediately.
+   * @type {HTMLIFrameElement}
+   * @private
+   */
+  this.iframe_ = null;
+
+  /**
+   * Extension panel handlers.
+   * @type {wtf.app.ui.ExtensionTabPanel.Handlers?}
+   * @private
+   */
+  this.handlers_ = null;
+
+  wtf.timing.setImmediate(function() {
+    // Create the iframe.
+    this.setupIframe_();
+    goog.asserts.assert(this.iframe_);
+
+    // Let the extension set itself up.
+    var idoc = this.iframe_.contentDocument;
+    goog.asserts.assert(idoc);
+    this.handlers_ = callback(idoc);
+  }, this);
+};
+goog.inherits(wtf.app.ui.ExtensionTabPanel, wtf.app.ui.TabPanel);
+
+
+/**
+ * @typedef {{
+ *   onLayout: (function(number, number))?,
+ *   onVisibilityChange: (function(boolean))?
+ * }}
+ */
+wtf.app.ui.ExtensionTabPanel.Handlers;
+
+
+/**
+ * @typedef {function(!Document):wtf.app.ui.ExtensionTabPanel.Handlers}
+ */
+wtf.app.ui.ExtensionTabPanel.Callback;
+
+
+/**
+ * @override
+ */
+wtf.app.ui.ExtensionTabPanel.prototype.createDom = function(dom) {
+  var el = dom.createElement(goog.dom.TagName.DIV);
+  goog.dom.classes.add(el, goog.getCssName('wtfAppUiTabPanel'));
+  return el;
+};
+
+
+/**
+ * Sets up the panel iframe.
+ * @private
+ */
+wtf.app.ui.ExtensionTabPanel.prototype.setupIframe_ = function() {
+  goog.asserts.assert(!this.iframe_);
+
+  var manifest = this.extension_.getManifest();
+
+  // Create iframe.
+  // We could use seamless on this (in Chrome 22+), but it's not much use with
+  // renamed CSS. Better would be to insert a default stylesheet with some
+  // common styles (buttons/etc).
+  var iframe = /** @type {!HTMLIFrameElement} */ (
+      this.getDom().createElement(goog.dom.TagName.IFRAME));
+  this.getRootElement().appendChild(iframe);
+
+  // Set base.
+  var idoc = iframe.contentDocument;
+  var baseUri = goog.Uri.resolve(window.location.href, manifest.getUrl());
+  var baseEl = idoc.createElement(goog.dom.TagName.BASE);
+  baseEl.href = baseUri.toString();
+  idoc.head.appendChild(baseEl);
+
+  // Set content size so it fits.
+  goog.style.setStyle(iframe, {
+    'width': '100%',
+    'height': '100%'
+  });
+
+  // Add scripts.
+  var scripts = this.options_['scripts'] || [];
+  for (var n = 0; n < scripts.length; n++) {
+    var script = idoc.createElement(goog.dom.TagName.SCRIPT);
+    script.src = scripts[n];
+    idoc.body.appendChild(script);
+  }
+
+  // Add stylesheets.
+  var stylesheets = this.options_['stylesheets'] || [];
+  for (var n = 0; n < stylesheets.length; n++) {
+    var link = idoc.createElement(goog.dom.TagName.LINK);
+    link.rel = 'stylesheet';
+    link.href = stylesheets[n];
+    link.type = 'text/css';
+    idoc.head.appendChild(link);
+  }
+
+  this.iframe_ = iframe;
+};
+
+
+/**
+ * @override
+ */
+wtf.app.ui.ExtensionTabPanel.prototype.layoutInternal = function() {
+  if (this.handlers_ && this.handlers_['onLayout']) {
+    var currentSize = goog.style.getSize(this.getRootElement());
+    this.handlers_['onLayout'](currentSize.width, currentSize.height);
+  }
+};
+
+
+/**
+ * @override
+ */
+wtf.app.ui.ExtensionTabPanel.prototype.setVisible = function(value) {
+  goog.base(this, 'setVisible', value);
+  if (this.handlers_ && this.handlers_['onVisibilityChange']) {
+    this.handlers_['onVisibilityChange'](value);
+  }
+};

--- a/src/wtf/app/ui/tabpanel.gss
+++ b/src/wtf/app/ui/tabpanel.gss
@@ -16,3 +16,10 @@
 
   background-color: white;
 }
+
+.wtfAppUiTabPanel iframe {
+  background-color: white;
+  border: 0;
+  padding: 0;
+  overflow: hidden;
+}

--- a/src/wtf/app/ui/tabpanel.js
+++ b/src/wtf/app/ui/tabpanel.js
@@ -144,5 +144,6 @@ goog.inherits(wtf.app.ui.EmptyTabPanel, wtf.app.ui.TabPanel);
 wtf.app.ui.EmptyTabPanel.prototype.createDom = function(dom) {
   var el = dom.createElement(goog.dom.TagName.DIV);
   goog.dom.classes.add(el, goog.getCssName('wtfAppUiTabPanel'));
+  dom.setTextContent(el, 'TODO');
   return el;
 };

--- a/src/wtf/app/ui/ui.js
+++ b/src/wtf/app/ui/ui.js
@@ -46,6 +46,9 @@ wtf.app.ui.show = function(opt_options) {
   // TODO(benvanik): switch to chrome platform when possible?
   var platform = new wtf.pal.BrowserPlatform();
 
+  // TODO(benvanik): options value for this/fancy ui/etc.
+  //wtf.ext.registerExtension('../extensions/diagrams/diagrams.json');
+
   // Add to DOM when it is ready.
   wtf.util.callWhenDomReady(function() {
     wtf.app.ui.showWhenDomLoaded_(platform, options);

--- a/src/wtf/ext/manifest.js
+++ b/src/wtf/ext/manifest.js
@@ -69,7 +69,6 @@ wtf.ext.Manifest = function(url, json) {
   if (jsonApp) {
     this.app_ = {
       scripts: jsonApp['scripts'] || [],
-      stylesheets: jsonApp['stylesheets'] || [],
       triggers: []
     };
     var jsonTriggers = jsonApp['triggers'];
@@ -97,7 +96,6 @@ wtf.ext.Manifest.TracingInfo;
 /**
  * @typedef {{
  *   scripts: !Array.<string>,
- *   stylesheets: !Array.<string>,
  *   triggers: !Array.<{type: string, name: string}>
  * }}
  */


### PR DESCRIPTION
App extensions are now loaded (in their own hidden iframes) and can create
panels via an API that also get their own iframes.
Need to add a way to add/toggle extensions.

The test extension draws a sankey diagram with d3, which is kind of cool.
