### PR TITLE
Switching initialization of WTF to take the options during prepare().

### DIFF
--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -20,6 +20,7 @@ Add the appropriate `<script>` tags to the HTML page:
         <!-- This MUST be the first script on the page! -->
         <script src="wtf_trace_web_js_compiled.js"></script>
         <script>
+          wtf.trace.prepare(/* optional options */);
           wtf.trace.start({
             'wtf.trace.mode': 'snapshotting',
             'wtf.trace.target': 'file://test'

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -91,7 +91,8 @@ also manually embed the extension scripts and register their manifests:
 
     <script src="wtf_trace_web_js_compiled.js"></script>
     <script>
-      wtf.trace.prepare();
+      var options = {...};
+      wtf.trace.prepare(options);
     </script>
     <script src="my/extension1/fileA.js"></script>
     <script src="my/extension1/fileB.js"></script>
@@ -99,9 +100,8 @@ also manually embed the extension scripts and register their manifests:
       wtf.ext.registerExtension('my/extension1/extension1.json');
     </script>
     <script>
-      var options = {...};
-      wtf.hud.prepare(options);
-      wtf.trace.start(options);
+      wtf.hud.prepare();
+      wtf.trace.start();
     </script>
 
 Note that `registerExtension` will only accept URLs that are either on the same
@@ -110,7 +110,8 @@ you can also pass the JSON object directly to `registerExtension`:
 
     <script src="wtf_trace_web_js_compiled.js"></script>
     <script>
-      wtf.trace.prepare();
+      var options = {...};
+      wtf.trace.prepare(options);
     </script>
     <script src="my/extension1/fileA.js"></script>
     <script src="my/extension1/fileB.js"></script>
@@ -121,9 +122,8 @@ you can also pass the JSON object directly to `registerExtension`:
       });
     </script>
     <script>
-      var options = {...};
-      wtf.hud.prepare(options);
-      wtf.trace.start(options);
+      wtf.hud.prepare();
+      wtf.trace.start();
     </script>
 
 ### Scripts

--- a/docs/node.md
+++ b/docs/node.md
@@ -37,9 +37,10 @@ Manual control:
     var wtf = require('tracing-framework');
 
     // Begin recording a trace...
-    wtf.trace.start({
+    wtf.trace.prepare({
       // Options
     });
+    wtf.trace.start();
 
     // Perform a snapshot.
     wtf.trace.snapshot();

--- a/docs/options.md
+++ b/docs/options.md
@@ -88,6 +88,32 @@ garbage collections, JIT activity, etc. This functionality relies on the
 injector extension or custom builds of Chromium. It introduces some overhead,
 such as an additional 0.1ms per XHR open/send.
 
+#### wtf.trace.provider.dom
+
+Set `wtf.trace.provider.dom` to 1+ to enable DOM instrumentation. This will
+add event handlers and other DOM hooks that may decrease performance slightly.
+
+Use `wtf.trace.initializeDomEventProperties(el, opt_recursive)` to setup the
+event hooks on new DOM elements added after the document has loaded. If this is
+not called on new DOM sub trees their events may not be tracked in all browsers.
+
+Use `wtf.trace.ignoreDomTree(el)` to ignore all of the events from a DOM tree.
+This is useful for hiding tracing/debug UI from the traces.
+
+#### wtf.trace.provider.image
+
+Set `wtf.trace.provider.image` to 1+ to enable Image/HTMLImageElement events.
+
+#### wtf.trace.provider.webworker
+
+Set `wtf.trace.provider.webworker` to 1+ to enable automatically instrumenting
+web workers as they are created and messages between workers.
+
+#### wtf.trace.provider.xhr
+
+Set `wtf.trace.provider.xhr` to 1+ to enable XHR events.
+This may incur additional overhead in event processing.
+
 ## HUD
 
 HUD options pertain only to the overlay used in browser-based injected runs.

--- a/injector/wtf-injector-chrome/wtf-injector.js
+++ b/injector/wtf-injector-chrome/wtf-injector.js
@@ -38,16 +38,17 @@ function main() {
     window.WTF_TRACE_SCRIPT_URL = traceScriptUrl;
   }, [traceScriptUrl]);
   injectScriptFile(traceScriptUrl);
-  injectScriptFunction(function() {
-    wtf.trace.prepare();
-  });
+  injectScriptFunction(function(options) {
+    wtf.trace.prepare(options);
+  }, [
+    options
+  ]);
 
   // Inject extensions, if required.
   var extensions = injectExtensions(options['wtf.extensions'] || []);
 
   // Inject preparation code to start tracing with the desired options.
   injectScriptFunction(startTracing, [
-    options,
     extensions
   ]);
 
@@ -158,11 +159,9 @@ function injectExtensions(manifestUrls) {
  * This function is stringified and passed to the page, so expect no closure
  * variables and all arguments must be serializable.
  *
- * @param {string|undefined} appEndpoint App endpoint in 'host:port' form.
- * @param {string} filePrefix Trace filename prefix.
  * @param {!Object.<!Object>} extensions A map of URL to extension JSON.
  */
-function startTracing(options, extensions) {
+function startTracing(extensions) {
   // NOTE: this code is injected by string and cannot access any closure
   //     variables!
   // Register extensions.
@@ -175,10 +174,10 @@ function startTracing(options, extensions) {
   }
 
   // Show HUD.
-  wtf.hud.prepare(options);
+  wtf.hud.prepare();
 
   // Start recording.
-  wtf.trace.start(options);
+  wtf.trace.start();
 };
 
 

--- a/src/wtf/hud/hud.js
+++ b/src/wtf/hud/hud.js
@@ -16,8 +16,8 @@ goog.provide('wtf.hud');
 goog.require('wtf.hud.Overlay');
 goog.require('wtf.trace');
 goog.require('wtf.trace.ISessionListener');
+goog.require('wtf.trace.prepare');
 goog.require('wtf.util');
-goog.require('wtf.util.Options');
 
 
 /**
@@ -33,21 +33,22 @@ wtf.hud.overlay_ = null;
  * Prepares the HUD and shows it on the given page.
  * The current tracing session will be used to source data for the HUD.
  *
+ * This will call {@see wtf.trace#prepare} if it has not already been called.
+ *
  * @param {Object=} opt_options Options overrides.
  * @param {Element=} opt_parentElement Element to display in.
  */
 wtf.hud.prepare = function(opt_options, opt_parentElement) {
-  // Always call tracing prepare to ensure it's ready before we run.
-  wtf.trace.prepare();
+  // Call prepare just in case.
+  wtf.trace.prepare(opt_options);
+  var traceManager = wtf.trace.getTraceManager();
 
   // Only one HUD per page.
   goog.dispose(wtf.hud.overlay_);
   wtf.hud.overlay_ = null;
 
-  // Get options; global with local overriding.
-  var options = new wtf.util.Options();
-  options.mixin(opt_options);
-  options.mixin(goog.global['wtf_hud_options']);
+  // Get combined options.
+  var options = traceManager.getOptions(opt_options);
 
   // Add to DOM when it is ready.
   wtf.util.callWhenDomReady(function() {

--- a/src/wtf/testing/benchmark.js
+++ b/src/wtf/testing/benchmark.js
@@ -139,10 +139,12 @@
       })(entry);
     }
 
-    wtf.trace.start({
+    var options = {
       'wtf.trace.mode': 'snapshotting',
       'wtf.trace.target': 'file://'
-    });
+    };
+    wtf.trace.prepare(options);
+    wtf.trace.start();
 
     suite.run({
       //'async': true,

--- a/src/wtf/trace/exports.js
+++ b/src/wtf/trace/exports.js
@@ -31,11 +31,7 @@ goog.require('wtf.trace.Scope');
 goog.require('wtf.trace.events');
 goog.require('wtf.trace.instrument');
 goog.require('wtf.trace.instrumentType');
-goog.require('wtf.trace.providers');
-
-
-// This is a hack, but required to get things registered without cycles.
-wtf.trace.providers.setup();
+goog.require('wtf.trace.prepare');
 
 
 /**

--- a/src/wtf/trace/node.js
+++ b/src/wtf/trace/node.js
@@ -16,6 +16,7 @@ goog.provide('wtf.trace.node');
 
 goog.require('wtf');
 goog.require('wtf.trace');
+goog.require('wtf.trace.prepare');
 
 
 if (wtf.NODE) {
@@ -24,6 +25,10 @@ if (wtf.NODE) {
    * @param {Object=} opt_options Options overrides.
    */
   wtf.trace.node.start = function(opt_options) {
+    // To make life easier we call prepare here.
+    wtf.trace.prepare(opt_options);
+
+    // Start tracing.
     wtf.trace.start(opt_options);
 
     // Setup process shutdown hook to snapshot/flush.

--- a/src/wtf/trace/prepare.js
+++ b/src/wtf/trace/prepare.js
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2012 Google, Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+/**
+ * @fileoverview Tracing preparation.
+ * This file contains the prepare method used to initialize WTF tracing.
+ * It's in its own file so that it can depend on files that many otherwise
+ * create cycles if it was in wtf.trace.
+ *
+ * @author benvanik@google.com (Ben Vanik)
+ */
+
+goog.provide('wtf.trace.prepare');
+
+goog.require('wtf.trace.TraceManager');
+goog.require('wtf.trace.providers');
+
+
+/**
+ * Main entry point for the tracing API.
+ * This must be called as soon as possible and preferably before any application
+ * code is executed (or even included on the page).
+ *
+ * This method does not setup a tracing session, but prepares the environment
+ * for one. It can be called many times but the options provided are not updated
+ * once it's been called.
+ *
+ * @param {Object=} opt_options Options overrides.
+ * @return {*} Ignored.
+ */
+wtf.trace.prepare = function(opt_options) {
+  var existingInstance = wtf.trace.TraceManager.getSharedInstance();
+  if (existingInstance) {
+    // TODO(benvanik): make sure options haven't changed?
+    return existingInstance;
+  }
+
+  // Setup.
+  var traceManager = new wtf.trace.TraceManager(opt_options);
+
+  // Add providers.
+  wtf.trace.providers.setup(traceManager);
+
+  // Stash the global object.
+  wtf.trace.TraceManager.setSharedInstance(traceManager);
+
+  return traceManager;
+};

--- a/src/wtf/trace/provider.js
+++ b/src/wtf/trace/provider.js
@@ -20,11 +20,19 @@ goog.require('goog.Disposable');
 /**
  * Abstract provider type for extensions to add events to the stream.
  *
+ * @param {!wtf.util.Options} options Options.
  * @constructor
  * @extends {goog.Disposable}
  */
-wtf.trace.Provider = function() {
+wtf.trace.Provider = function(options) {
   goog.base(this);
+
+  /**
+   * Shared trace options.
+   * @type {!wtf.util.Options}
+   * @protected
+   */
+  this.options = options;
 
   /**
    * A list of injections performed by this provider.

--- a/src/wtf/trace/providers/consoleprovider.js
+++ b/src/wtf/trace/providers/consoleprovider.js
@@ -21,11 +21,12 @@ goog.require('wtf.trace.Provider');
 /**
  * Provides the console API events.
  *
+ * @param {!wtf.util.Options} options Options.
  * @constructor
  * @extends {wtf.trace.Provider}
  */
-wtf.trace.providers.ConsoleProvider = function() {
-  goog.base(this);
+wtf.trace.providers.ConsoleProvider = function(options) {
+  goog.base(this, options);
 
   this.injectConsoleProfiling_();
 };

--- a/src/wtf/trace/providers/domprovider.js
+++ b/src/wtf/trace/providers/domprovider.js
@@ -21,13 +21,19 @@ goog.require('wtf.trace.eventtarget');
 /**
  * Provides DOM events for common DOM types.
  *
+ * @param {!wtf.util.Options} options Options.
  * @constructor
  * @extends {wtf.trace.Provider}
  */
-wtf.trace.providers.DomProvider = function() {
-  goog.base(this);
+wtf.trace.providers.DomProvider = function(options) {
+  goog.base(this, options);
 
   if (!goog.global['document']) {
+    return;
+  }
+
+  var level = options.getNumber('wtf.trace.provider.dom', 1);
+  if (!level) {
     return;
   }
 
@@ -52,6 +58,27 @@ wtf.trace.providers.DomProvider = function() {
   }
 };
 goog.inherits(wtf.trace.providers.DomProvider, wtf.trace.Provider);
+
+
+/**
+ * @override
+ */
+wtf.trace.providers.DomProvider.prototype.getSettingsSectionConfigs =
+    function() {
+  return [
+    {
+      'title': 'DOM',
+      'widgets': [
+        {
+          'type': 'checkbox',
+          'key': 'wtf.trace.provider.dom',
+          'title': 'Enabled',
+          'default': true
+        }
+      ]
+    }
+  ];
+};
 
 
 /**

--- a/src/wtf/trace/providers/extendedinfoprovider.js
+++ b/src/wtf/trace/providers/extendedinfoprovider.js
@@ -26,11 +26,17 @@ goog.require('wtf.trace.events');
 /**
  * Inserts data from the extension extended information proxy.
  *
+ * @param {!wtf.util.Options} options Options.
  * @constructor
  * @extends {wtf.trace.Provider}
  */
-wtf.trace.providers.ExtendedInfoProvider = function() {
-  goog.base(this);
+wtf.trace.providers.ExtendedInfoProvider = function(options) {
+  goog.base(this, options);
+
+  var level = options.getNumber('wtf.trace.provider.browser', 1);
+  if (!level) {
+    return;
+  }
 
   /**
    * Dispatch table for each event type that comes from the extension.
@@ -71,7 +77,7 @@ wtf.trace.providers.ExtendedInfoProvider.prototype.getSettingsSectionConfigs =
     function() {
   return [
     {
-      'title': 'System Events',
+      'title': 'Browser Events',
       'widgets': [
         {
           'type': 'checkbox',

--- a/src/wtf/trace/providers/imageprovider.js
+++ b/src/wtf/trace/providers/imageprovider.js
@@ -21,19 +21,46 @@ goog.require('wtf.trace.eventtarget');
 /**
  * Provides Image API events.
  *
+ * @param {!wtf.util.Options} options Options.
  * @constructor
  * @extends {wtf.trace.Provider}
  */
-wtf.trace.providers.ImageProvider = function() {
-  goog.base(this);
+wtf.trace.providers.ImageProvider = function(options) {
+  goog.base(this, options);
 
   if (!goog.global['Image']) {
+    return;
+  }
+
+  var level = options.getNumber('wtf.trace.provider.image', 1);
+  if (!level) {
     return;
   }
 
   this.injectImage_();
 };
 goog.inherits(wtf.trace.providers.ImageProvider, wtf.trace.Provider);
+
+
+/**
+ * @override
+ */
+wtf.trace.providers.ImageProvider.prototype.getSettingsSectionConfigs =
+    function() {
+  return [
+    {
+      'title': 'Images',
+      'widgets': [
+        {
+          'type': 'checkbox',
+          'key': 'wtf.trace.provider.image',
+          'title': 'Enabled',
+          'default': true
+        }
+      ]
+    }
+  ];
+};
 
 
 /**

--- a/src/wtf/trace/providers/providers.js
+++ b/src/wtf/trace/providers/providers.js
@@ -14,7 +14,6 @@
 goog.provide('wtf.trace.providers');
 
 goog.require('wtf');
-goog.require('wtf.trace');
 goog.require('wtf.trace.providers.ConsoleProvider');
 goog.require('wtf.trace.providers.DomProvider');
 goog.require('wtf.trace.providers.ExtendedInfoProvider');
@@ -26,21 +25,28 @@ goog.require('wtf.trace.providers.XhrProvider');
 
 /**
  * Sets up all providers.
+ * @param {!wtf.trace.TraceManager} traceManager Trace manager.
  */
-wtf.trace.providers.setup = function() {
-  var traceManager = wtf.trace.getTraceManager();
-  traceManager.addProvider(new wtf.trace.providers.ConsoleProvider());
-  traceManager.addProvider(new wtf.trace.providers.TimingProvider());
+wtf.trace.providers.setup = function(traceManager) {
+  var options = traceManager.getOptions();
+
+  traceManager.addProvider(
+      new wtf.trace.providers.ConsoleProvider(options));
+  traceManager.addProvider(
+      new wtf.trace.providers.TimingProvider(options));
 
   // Browser only:
   if (!wtf.NODE) {
-    traceManager.addProvider(new wtf.trace.providers.DomProvider());
-    traceManager.addProvider(new wtf.trace.providers.ImageProvider());
-    traceManager.addProvider(new wtf.trace.providers.XhrProvider());
-
-    traceManager.addProvider(new wtf.trace.providers.WebWorkerProvider());
-
-    traceManager.addProvider(new wtf.trace.providers.ExtendedInfoProvider());
+    traceManager.addProvider(
+        new wtf.trace.providers.DomProvider(options));
+    traceManager.addProvider(
+        new wtf.trace.providers.ImageProvider(options));
+    traceManager.addProvider(
+        new wtf.trace.providers.XhrProvider(options));
+    traceManager.addProvider(
+        new wtf.trace.providers.WebWorkerProvider(options));
+    traceManager.addProvider(
+        new wtf.trace.providers.ExtendedInfoProvider(options));
   }
 
   // Node only:

--- a/src/wtf/trace/providers/timingprovider.js
+++ b/src/wtf/trace/providers/timingprovider.js
@@ -26,11 +26,12 @@ goog.require('wtf.trace.events');
  * Provides the timing events common between browsers and node.js, such as
  * timers, rAF, etc.
  *
+ * @param {!wtf.util.Options} options Options.
  * @constructor
  * @extends {wtf.trace.Provider}
  */
-wtf.trace.providers.TimingProvider = function() {
-  goog.base(this);
+wtf.trace.providers.TimingProvider = function(options) {
+  goog.base(this, options);
 
   this.injectTimeouts_();
   this.injectSetImmediate_();

--- a/src/wtf/trace/providers/webworkerprovider.js
+++ b/src/wtf/trace/providers/webworkerprovider.js
@@ -28,11 +28,17 @@ goog.require('wtf.trace.util');
 /**
  * Provides Web Worker API events.
  *
+ * @param {!wtf.util.Options} options Options.
  * @constructor
  * @extends {wtf.trace.Provider}
  */
-wtf.trace.providers.WebWorkerProvider = function() {
-  goog.base(this);
+wtf.trace.providers.WebWorkerProvider = function(options) {
+  goog.base(this, options);
+
+  var level = options.getNumber('wtf.trace.provider.webworker', 1);
+  if (!level) {
+    return;
+  }
 
   // TODO(benvanik): use weak references (WeakMap) when supported.
   /**
@@ -79,8 +85,14 @@ wtf.trace.providers.WebWorkerProvider.prototype.getSettingsSectionConfigs =
       'widgets': [
         {
           'type': 'checkbox',
+          'key': 'wtf.trace.provider.webworker',
+          'title': 'Enabled',
+          'default': true
+        },
+        {
+          'type': 'checkbox',
           'key': 'wtf.trace.provider.webworker.inject',
-          'title': 'Auto Inject',
+          'title': 'Auto Inject in to Workers',
           'default': true
         }
       ]
@@ -144,8 +156,9 @@ wtf.trace.providers.WebWorkerProvider.prototype.injectBrowserShim_ =
       'this.WTF_WORKER_ID = ' + this.workerId_ + ';',
       'this.WTF_WORKER_BASE_URI = "' + goog.global.location.href + '";',
       'importScripts("' + wtfUrl + '");',
-      'wtf.trace.start({',
+      'wtf.trace.prepare({',
       '});',
+      'wtf.trace.start();',
       'importScripts("' + resolvedScriptUrl + '");'
     ].join('\n');
     var shimBlob = new Blob([shimScript], {

--- a/src/wtf/trace/providers/xhrprovider.js
+++ b/src/wtf/trace/providers/xhrprovider.js
@@ -26,19 +26,46 @@ goog.require('wtf.trace.eventtarget.BaseEventTarget');
 /**
  * Provides XMLHttpRequest API events.
  *
+ * @param {!wtf.util.Options} options Options.
  * @constructor
  * @extends {wtf.trace.Provider}
  */
-wtf.trace.providers.XhrProvider = function() {
-  goog.base(this);
+wtf.trace.providers.XhrProvider = function(options) {
+  goog.base(this, options);
 
   if (!goog.global['XMLHttpRequest']) {
+    return;
+  }
+
+  var level = options.getNumber('wtf.trace.provider.xhr', 1);
+  if (!level) {
     return;
   }
 
   this.injectXhr_();
 };
 goog.inherits(wtf.trace.providers.XhrProvider, wtf.trace.Provider);
+
+
+/**
+ * @override
+ */
+wtf.trace.providers.XhrProvider.prototype.getSettingsSectionConfigs =
+    function() {
+  return [
+    {
+      'title': 'XMLHttpRequest',
+      'widgets': [
+        {
+          'type': 'checkbox',
+          'key': 'wtf.trace.provider.xhr',
+          'title': 'Enabled',
+          'default': true
+        }
+      ]
+    }
+  ];
+};
 
 
 /**

--- a/src/wtf/util/options.js
+++ b/src/wtf/util/options.js
@@ -117,6 +117,17 @@ wtf.util.Options.prototype.clear = function() {
 
 
 /**
+ * Clones this options object and all values.
+ * @return {!wtf.util.Options} New clone.
+ */
+wtf.util.Options.prototype.clone = function() {
+  var clone = new wtf.util.Options();
+  clone.mixin(this.obj_);
+  return clone;
+};
+
+
+/**
  * Gets a clone of the options map.
  * @return {!Object} Options map clone.
  */

--- a/test/test.html
+++ b/test/test.html
@@ -14,8 +14,9 @@
     var options = {
       'wtf.trace.target': 'file://test'
     };
-    wtf.hud.prepare(options);
-    wtf.trace.start(options);
+    wtf.trace.prepare(options);
+    wtf.hud.prepare();
+    wtf.trace.start();
   </script>
 
   <br/>


### PR DESCRIPTION
This makes it possible to toggle providers and make other startup-time
decisions.
With this change it's required that prepare (either/both of
wtf.trace.prepare or wtf.hud.prepare) is called before wtf.trace.start.

Partial work on #213.
