### PR TITLE
Adding wtf.trace.snapshotAll which can be used to asynchronously grab snapshots from all contexts.

### DIFF
--- a/src/wtf/hud/hud.js
+++ b/src/wtf/hud/hud.js
@@ -113,6 +113,12 @@ wtf.hud.SessionListener_.prototype.sessionStopped = function(session) {
 
 
 /**
+ * @override
+ */
+wtf.hud.SessionListener_.prototype.requestSnapshots = goog.nullFunction;
+
+
+/**
  * Shows the HUD, if it is hidden.
  */
 wtf.hud.show = function() {

--- a/src/wtf/io/memorywritestream.js
+++ b/src/wtf/io/memorywritestream.js
@@ -22,11 +22,12 @@ goog.require('wtf.io.WriteStream');
  * Memory write stream.
  * Clones all buffers and keeps them around forever.
  *
- * @param {!Array.<!wtf.io.ByteArray>} resultArray Array to fill with results.
+ * @param {Array.<!wtf.io.ByteArray>=} opt_resultArray Array to fill with
+ *     results.
  * @constructor
  * @extends {wtf.io.WriteStream}
  */
-wtf.io.MemoryWriteStream = function(resultArray) {
+wtf.io.MemoryWriteStream = function(opt_resultArray) {
   goog.base(this);
 
   /**
@@ -34,7 +35,7 @@ wtf.io.MemoryWriteStream = function(resultArray) {
    * @type {!Array.<!wtf.io.ByteArray>}
    * @private
    */
-  this.resultArray_ = resultArray;
+  this.resultArray_ = opt_resultArray || [];
 
   /**
    * Cloned memory buffers.

--- a/src/wtf/trace/eventtarget.js
+++ b/src/wtf/trace/eventtarget.js
@@ -497,6 +497,11 @@ wtf.trace.eventtarget.BaseEventTarget.prototype.setEventHook = function(
  * @param {Event} e Event.
  */
 wtf.trace.eventtarget.BaseEventTarget.prototype['dispatchEvent'] = function(e) {
+  // Ignore events marked by implementations as being WTF-specific.
+  if (e['__wtf_ignore__']) {
+    return;
+  }
+
   var onListener = this.onListeners_[e.type];
   if (onListener) {
     this.dispatchToListener(e, onListener);

--- a/src/wtf/trace/exports.js
+++ b/src/wtf/trace/exports.js
@@ -66,6 +66,9 @@ if (wtf.trace.exports.ENABLE_EXPORTS) {
       'wtf.trace.snapshot',
       wtf.trace.snapshot);
   goog.exportSymbol(
+      'wtf.trace.snapshotAll',
+      wtf.trace.snapshotAll);
+  goog.exportSymbol(
       'wtf.trace.reset',
       wtf.trace.reset);
   goog.exportSymbol(

--- a/src/wtf/trace/providers/providers.js
+++ b/src/wtf/trace/providers/providers.js
@@ -44,7 +44,7 @@ wtf.trace.providers.setup = function(traceManager) {
     traceManager.addProvider(
         new wtf.trace.providers.XhrProvider(options));
     traceManager.addProvider(
-        new wtf.trace.providers.WebWorkerProvider(options));
+        new wtf.trace.providers.WebWorkerProvider(traceManager, options));
     traceManager.addProvider(
         new wtf.trace.providers.ExtendedInfoProvider(options));
   }

--- a/src/wtf/trace/snapshottingsession.js
+++ b/src/wtf/trace/snapshottingsession.js
@@ -133,16 +133,18 @@ wtf.trace.SnapshottingSession.prototype.reset = function() {
 
 /**
  * Writes a snapshot of the current state.
- * @param {!function():!wtf.io.WriteStream} streamCreator Factory function for
- *     streams. This is only called if a snapshot is going to be created. After
- *     the snapshot is written the stream is disposed.
- * @param {Object=} opt_scope Scope for the creation function.
+ * @param {!function(this:T):!wtf.io.WriteStream} streamCreator Factory function
+ *     for streams. This is only called if a snapshot is going to be created.
+ *     After the snapshot is written the stream is disposed.
+ * @param {T=} opt_scope Scope for the creation function.
+ * @return {boolean} True if a snapshot was written.
+ * @template T
  */
 wtf.trace.SnapshottingSession.prototype.snapshot = function(
     streamCreator, opt_scope) {
   // TODO(benvanik): something smarter when there are overlapping writes?
   if (this.pendingWrites_) {
-    return;
+    return false;
   }
 
   // TODO(benvanik): write a snapshot event?
@@ -201,6 +203,8 @@ wtf.trace.SnapshottingSession.prototype.snapshot = function(
     // Pending writes - normal acquire path.
     this.currentBuffer = this.nextBuffer();
   }
+
+  return !!stream;
 };
 
 

--- a/src/wtf/trace/trace.js
+++ b/src/wtf/trace/trace.js
@@ -222,15 +222,37 @@ wtf.trace.start = function(opt_options) {
 wtf.trace.snapshot = function(opt_targetValue) {
   var traceManager = wtf.trace.getTraceManager();
   var session = traceManager.getCurrentSession();
-  if (session instanceof wtf.trace.SnapshottingSession) {
-    if (goog.isFunction(opt_targetValue)) {
-      session.snapshot(opt_targetValue);
-    } else {
-      session.snapshot(function() {
-        return wtf.trace.createStream_(session.getOptions(), opt_targetValue);
-      });
-    }
+  if (!session || !(session instanceof wtf.trace.SnapshottingSession)) {
+    return;
   }
+
+  if (goog.isFunction(opt_targetValue)) {
+    session.snapshot(opt_targetValue);
+  } else {
+    session.snapshot(function() {
+      return wtf.trace.createStream_(session.getOptions(), opt_targetValue);
+    });
+  }
+};
+
+
+/**
+ * Asynchronously snapshots all contexts.
+ * This will take a snapshot of the current context as well as any dependent
+ * ones such as servers or worker threads. The results are sent to the callback
+ * when they have all been returned.
+ * If the call is going to be ignored (no active session) or fails the callback
+ * will fire on the next javascript tick with a null value.
+ *
+ * @param {function(this:T, Array.<!wtf.io.ByteArray>)} callback Function called
+ *     when all buffers are available. The value will be null if an error
+ *     occurred.
+ * @param {T=} opt_scope Callback scope.
+ * @template T
+ */
+wtf.trace.snapshotAll = function(callback, opt_scope) {
+  var traceManager = wtf.trace.getTraceManager();
+  traceManager.requestSnapshots(callback, opt_scope);
 };
 
 

--- a/src/wtf/wtf.js
+++ b/src/wtf/wtf.js
@@ -46,7 +46,7 @@ wtf.hasHighResolutionTimes =
 
 
 /**
- * Create a high performance time function from window.performance, if present.
+ * Creates a high performance time function from window.performance, if present.
  * @return {number} A time, in ms.
  * @private
  */
@@ -82,7 +82,7 @@ wtf.performanceNow_ = (function() {
  *     performance.now.
  * @private
  */
-wtf.computeHighPrecissionTimebase_ = function() {
+wtf.computeHighPrecisionTimebase_ = function() {
   var initialDateNow = Date.now();
   var syncedDateNow;
   var syncedPerfNow;
@@ -120,7 +120,7 @@ wtf.timebase = (function() {
     }
   } else {
     if (wtf.performanceNow_) {
-      timebase = wtf.computeHighPrecissionTimebase_();
+      timebase = wtf.computeHighPrecisionTimebase_();
     } else {
       timebase = Date.now();
     }
@@ -167,13 +167,10 @@ wtf.now = (function() {
     return wtf.performanceNow_;
   } else {
     var timebase = wtf.timebase();
-    if (!Date.now) {
-      return function wtfNowDate() {
-        return Date.now() - timebase;
-      };
-    } else {
-      return Date.now;
-    }
+    var now = Date.now;
+    return function wtfNowDate() {
+      return now() - timebase;
+    };
   }
 })();
 

--- a/wtf-trace-shim.js
+++ b/wtf-trace-shim.js
@@ -225,6 +225,24 @@ wtfapi.trace.snapshot = wtfapi.PRESENT ?
 
 
 /**
+ * Asynchronously snapshots all contexts.
+ * This will take a snapshot of the current context as well as any dependent
+ * ones such as servers or worker threads. The results are sent to the callback
+ * when they have all been returned.
+ * If the call is going to be ignored (no active session) or fails the callback
+ * will fire on the next javascript tick with a null value.
+ *
+ * @param {function(this:T, Array.<!wtf.io.ByteArray>)} callback Function called
+ *     when all buffers are available. The value will be null if an error
+ *     occurred.
+ * @param {T=} opt_scope Callback scope.
+ * @template T
+ */
+wtfapi.trace.snapshotAll = wtfapi.PRESENT ?
+    goog.global['wtf']['trace']['snapshotAll'] : goog.nullFunction;
+
+
+/**
  * Clears all data in the current session by resetting all buffers.
  * This is only valid in snapshotting sessions.
  */


### PR DESCRIPTION
This allows for workers to have their snapshots taken and shown in the
UI. Unfortunately without performance.now this is a little useless right
now so I'm disabling it by default.

Work on #96.
