### PR TITLE
Fixes bad scope order/overlap issues.

### DIFF
--- a/extensions/chrometracing/extension-trace.js
+++ b/extensions/chrometracing/extension-trace.js
@@ -5,6 +5,10 @@ if (!available) {
   return;
 }
 
+// TODO(benvanik): find a way to get this - either via the extension APIs
+//     or asking the user for it.
+var currentThreadId = 10406;
+
 var active = false;
 var syncIntervalId = undefined;
 
@@ -18,6 +22,7 @@ function showProgress(message) {
     progressDiv.style.backgroundColor = 'white';
     progressDiv.style.border = '1px solid black';
     progressDiv.style.color = 'black';
+    progressDiv.style.zIndex = 9999999;
     document.body.appendChild(progressDiv);
   }
   progressDiv.innerHTML = message;
@@ -71,19 +76,18 @@ wtf.hud.addButton({
 });
 
 function processTraceData(data) {
-  // TODO(benvanik): find a way to get this - either via the extension APIs
-  //     or asking the user for it.
-  var currentThreadId = 3221;
-
   var threads = {};
   var timeDelta = 0;
 
-  data = JSON.parse('[' + data + ']');
+  data = JSON.parse('[' + data.join(',') + ']');
 
   // First we need to walk the data to find the threads by __metadata.
   // Unfortunately these come out of order.
   for (var n = 0; n < data.length; n++) {
     var e = data[n];
+    if (!e) {
+      continue;
+    }
 
     var thread = threads[e.tid];
     if (!thread) {

--- a/src/wtf/analysis/db/eventlist.js
+++ b/src/wtf/analysis/db/eventlist.js
@@ -243,7 +243,7 @@ wtf.analysis.db.EventList.prototype.search = function(time, filter) {
  * @private
  */
 wtf.analysis.db.EventList.findEventWithScope_ = function(e) {
-  return !!e.scope && !!e.scope.getEnterEvent() && !!e.scope.getLeaveEvent();
+  return !!e.scope && !!e.scope.getEnterEvent();
 };
 
 
@@ -263,7 +263,7 @@ wtf.analysis.db.EventList.prototype.findEnclosingScope = function(time) {
     var enter = scope.getEnterEvent();
     var leave = scope.getLeaveEvent();
     if (enter && enter.time <= time &&
-        leave && leave.time >= time) {
+        (!leave || leave.time >= time)) {
       return scope;
     }
   }

--- a/src/wtf/analysis/scope.js
+++ b/src/wtf/analysis/scope.js
@@ -132,6 +132,15 @@ wtf.analysis.Scope.prototype.setEnterEvent = function(e) {
 
 
 /**
+ * Gets the time the scope was entered, if it was.
+ * @return {number} Time of enter or 0.
+ */
+wtf.analysis.Scope.prototype.getEnterTime = function() {
+  return this.enterEvent_ ? this.enterEvent_.time : 0;
+};
+
+
+/**
  * Gets the leave event for the scope.
  * @return {wtf.analysis.Event} Leave event, if any.
  */
@@ -146,6 +155,15 @@ wtf.analysis.Scope.prototype.getLeaveEvent = function() {
  */
 wtf.analysis.Scope.prototype.setLeaveEvent = function(e) {
   this.leaveEvent_ = e;
+};
+
+
+/**
+ * Gets the time the scope was left, if it was.
+ * @return {number} Time of leave or 0.
+ */
+wtf.analysis.Scope.prototype.getLeaveTime = function() {
+  return this.leaveEvent_ ? this.leaveEvent_.time : 0;
 };
 
 

--- a/src/wtf/analysis/sources/jsontracesource.js
+++ b/src/wtf/analysis/sources/jsontracesource.js
@@ -60,12 +60,20 @@ wtf.analysis.sources.JsonTraceSource = function(traceListener, sourceData) {
    */
   this.currentZone_ = traceListener.getDefaultZone();
 
-  // If the input is a string it needs to be parsed (and maybe fixed up).
-  if (goog.isString(sourceData)) {
-    sourceData = this.parseJson_(sourceData);
-  }
-  if (goog.isObject(sourceData) && !goog.isArray(sourceData)) {
-    sourceData = /** @type {!Array} */ (sourceData['events']);
+  try {
+    // If the input is a string it needs to be parsed (and maybe fixed up).
+    if (goog.isString(sourceData)) {
+      sourceData = this.parseJson_(sourceData);
+    }
+    if (goog.isObject(sourceData) && !goog.isArray(sourceData)) {
+      sourceData = /** @type {!Array} */ (sourceData['events']);
+    }
+  } catch (e) {
+    traceListener.sourceError(
+        'Error parsing data',
+        'The file could not be parsed as JSON. Perhaps ' +
+        'it\'s corrupted?\n' + e);
+    return;
   }
 
   if (goog.isArray(sourceData)) {

--- a/test/data/outoforder.wtf-json
+++ b/test/data/outoforder.wtf-json
@@ -1,0 +1,74 @@
+[
+  {
+    "type": "wtf.json#header",
+    "format_version": 2,
+    "timebase": 1000
+  },
+  {
+    "type": "wtf.event#define",
+    "signature": "my.custom#scopeEvent",
+    "event_id": 1
+  },
+  {
+    "type": "wtf.event#define",
+    "signature": "ooo",
+    "event_id": 2
+  },
+  {
+    "event": "wtf.zone#create",
+    "time": 0,
+    "args": [
+      1000,
+      "Runtime",
+      "script",
+      ""
+    ]
+  },
+  {
+    "event": "wtf.zone#set",
+    "time": 0,
+    "args": [
+      1000
+    ]
+  },
+  {
+    "event": 1,
+    "time": 0
+  },
+  {
+    "event": -1,
+    "time": 1000
+  },
+  {
+    "event": 1,
+    "time": 2000
+  },
+  {
+    "event": -1,
+    "time": 3000
+  },
+  {
+    "event": 1,
+    "time": 4000
+  },
+  {
+    "event": -1,
+    "time": 5000
+  },
+  {
+    "event": 2,
+    "time": 100
+  },
+  {
+    "event": -1,
+    "time": 900
+  },
+  {
+    "event": 1,
+    "time": 5500
+  },
+  {
+    "event": -1,
+    "time": 6000
+  }
+]


### PR DESCRIPTION
This was caused by the out-of-order event handling causing issues with
parenting of scopes. The cleanest fix is to just sort and insert in order
instead of trying to be clever, which this does. It's a bit slower, but not
by much and makes things work right.

Also fixing the tracing code for nightly chromium.

Fixes #207.
Work on #211.
