### PR TITLE
Passing around an 'event session context' instead of just a 'session ptr'.

### DIFF
--- a/src/wtf/trace/eventregistry.js
+++ b/src/wtf/trace/eventregistry.js
@@ -16,6 +16,7 @@ goog.provide('wtf.trace.EventRegistry');
 goog.require('goog.asserts');
 goog.require('goog.events');
 goog.require('wtf.events.EventEmitter');
+goog.require('wtf.trace.EventSessionContext');
 goog.require('wtf.trace.EventTypeBuilder');
 
 
@@ -34,10 +35,10 @@ wtf.trace.EventRegistry = function() {
    * A 'pointer' to the current session.
    * This is kept in sync with {@see #currentSession_} and is used to allow
    * for resetting the session in generated closures.
-   * @type {!Array.<wtf.trace.Session>}
+   * @type {!wtf.trace.EventSessionContextType}
    * @private
    */
-  this.currentSessionPtr_ = [null];
+  this.eventSessionContext_ = wtf.trace.EventSessionContext.create();
 
   /**
    * A list of all registered events.
@@ -58,11 +59,11 @@ goog.inherits(wtf.trace.EventRegistry, wtf.events.EventEmitter);
 
 
 /**
- * Gets the current session pointer.
- * @return {!Array.<wtf.trace.Session>} Current session pointer.
+ * Gets the event session context.
+ * @return {!wtf.trace.EventSessionContextType} Event session context.
  */
-wtf.trace.EventRegistry.prototype.getSessionPtr = function() {
-  return this.currentSessionPtr_;
+wtf.trace.EventRegistry.prototype.getEventSessionContext = function() {
+  return this.eventSessionContext_;
 };
 
 
@@ -80,7 +81,7 @@ wtf.trace.EventRegistry.prototype.registerEventType = function(eventType) {
   this.eventTypesByName_[eventType.name] = eventType;
 
   this.eventTypeBuilder_ = new wtf.trace.EventTypeBuilder();
-  eventType.generateCode(this.eventTypeBuilder_, this.currentSessionPtr_);
+  eventType.generateCode(this.eventTypeBuilder_, this.eventSessionContext_);
 
   this.emitEvent(wtf.trace.EventRegistry.EventType.EVENT_TYPE_REGISTERED,
       eventType);

--- a/src/wtf/trace/eventsessioncontext.js
+++ b/src/wtf/trace/eventsessioncontext.js
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2013 Google, Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+/**
+ * @fileoverview Shared context referencing session state.
+ *
+ * @author benvanik@google.com (Ben Vanik)
+ */
+
+goog.provide('wtf.trace.EventSessionContext');
+goog.provide('wtf.trace.EventSessionContextType');
+
+
+/**
+ * Shared session context.
+ * One of these is instantiated by the {@see wtf.trace.TraceManager} at startup
+ * and bound to all generated event functions. That instance is kept the same
+ * across all trace sessions that run, with only its contents changing.
+ *
+ * In order to make this easier to use from generated code it is just a simple
+ * array with the elements inside of it. Use the static accessor methods to
+ * manipulate it.
+ */
+wtf.trace.EventSessionContext = function() {};
+
+
+/**
+ * The event session context type.
+ * @typedef {!Array}
+ */
+wtf.trace.EventSessionContextType;
+
+
+/**
+ * Creates a new context.
+ * @return {!wtf.trace.EventSessionContextType} New context.
+ */
+wtf.trace.EventSessionContext.create = function() {
+  return new Array(2);
+};
+
+
+/**
+ * Initializes a context for the given session.
+ * @param {!wtf.trace.EventSessionContextType} context Context.
+ * @param {wtf.trace.Session} session Trace session, if any.
+ */
+wtf.trace.EventSessionContext.init = function(context, session) {
+  context[0] = session;
+};
+
+
+/**
+ * Sets the buffer on the context.
+ * @param {!wtf.trace.EventSessionContextType} context Context.
+ * @param {!wtf.io.Buffer} buffer New buffer.
+ */
+wtf.trace.EventSessionContext.setBuffer = function(context, buffer) {
+  context[1] = buffer;
+};

--- a/src/wtf/trace/eventtype.js
+++ b/src/wtf/trace/eventtype.js
@@ -132,11 +132,10 @@ wtf.trace.EventType.prototype.getArgString = function() {
 /**
  * Generates event append code bound to the given session.
  * @param {!wtf.trace.EventTypeBuilder} builder Event type builder.
- * @param {!Array.<wtf.trace.Session>} sessionPtr An array containing a
- *     reference to the target trace session.
+ * @param {!wtf.trace.EventSessionContextType} context Event session context.
  */
-wtf.trace.EventType.prototype.generateCode = function(builder, sessionPtr) {
-  this.append = builder.generate(sessionPtr, this);
+wtf.trace.EventType.prototype.generateCode = function(builder, context) {
+  this.append = builder.generate(context, this);
 };
 
 


### PR DESCRIPTION
This will make it easier to inline more checks into the generated event
tracing code in the future. This change inlines buffer capacity checks,
avoiding to call to acquireBuffer when not needed.
