### PR TITLE
Refactoring the loading system and adding a dialog.

### DIFF
--- a/injector/wtf-injector-chrome/injectedtab.js
+++ b/injector/wtf-injector-chrome/injectedtab.js
@@ -187,7 +187,8 @@ InjectedTab.prototype.messageReceived_ = function(data, port) {
       this.extension_.showSnapshot(
           tab,
           data['page_url'],
-          data['content_type'],
+          data['content_types'],
+          data['content_sources'],
           data['content_urls'],
           data['content_length']);
       break;

--- a/injector/wtf-injector-chrome/popup.html
+++ b/injector/wtf-injector-chrome/popup.html
@@ -6,7 +6,7 @@
     <script src="popup.js"></script>
   </head>
   <body class="k">
-    <div class="kButtonBar">
+    <div class="kButtonBar buttonBar">
       <a class="kButton buttonShowUi" title="Show the Web Tracing Framework UI">Show UI</a>
       <a class="kButton buttonResetSettings" title="Reset all page tracing settings for this page to their default values">Reset Page Settings</a>
       <a class="kButton kButtonAction buttonToggleInjector" title="Toggle the tracing injection code">Enable</a>

--- a/injector/wtf-injector-chrome/popup.less
+++ b/injector/wtf-injector-chrome/popup.less
@@ -20,6 +20,10 @@ body {
   white-space: nowrap;
 }
 
+.buttonBar {
+  min-width: 280px;
+}
+
 .buttonToggleInjector {}
 .buttonResetSettings {}
 .buttonShowUi {}

--- a/src/wtf/app/background/backgroundpage.js
+++ b/src/wtf/app/background/backgroundpage.js
@@ -230,7 +230,7 @@ wtf.app.background.BackgroundPage.prototype.queueMessage_ = function(message) {
 
 /**
  * Handles incoming snapshot data events.
- * @param {string} contentType Snapshot content type.
+ * @param {!string} contentType Snapshot content type.
  * @param {!Uint8Array} data Snapshot data.
  * @private
  */
@@ -239,7 +239,7 @@ wtf.app.background.BackgroundPage.prototype.snapshotReceived_ = function(
   this.showWindow_(function() {
     this.queueMessage_({
       'command': 'snapshot',
-      'content_type': contentType,
+      'content_types': [contentType],
       'content_buffers': [data],
       'content_length': data.length
     });

--- a/src/wtf/app/background/serviceendpoint.js
+++ b/src/wtf/app/background/serviceendpoint.js
@@ -33,7 +33,7 @@ goog.inherits(wtf.app.background.ServiceEndpoint, wtf.events.EventEmitter);
 
 /**
  * Emits a new snapshot.
- * @param {string} contentType Snapshot content type.
+ * @param {!string} contentType Snapshot content type.
  * @param {!Uint8Array} data Snapshot data.
  * @protected
  */

--- a/src/wtf/app/ui/loader.js
+++ b/src/wtf/app/ui/loader.js
@@ -1,0 +1,480 @@
+/**
+ * Copyright 2013 Google, Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+/**
+ * @fileoverview Document loader utility.
+ *
+ * @author benvanik@google.com (Ben Vanik)
+ */
+
+goog.provide('wtf.app.ui.Loader');
+
+goog.require('goog.Disposable');
+goog.require('goog.array');
+goog.require('goog.asserts');
+goog.require('goog.async.DeferredList');
+goog.require('goog.dom.TagName');
+goog.require('goog.events');
+goog.require('goog.events.EventType');
+goog.require('goog.result');
+goog.require('goog.string');
+goog.require('wtf.app.ui.BufferLoaderEntry');
+goog.require('wtf.app.ui.FileLoaderEntry');
+goog.require('wtf.app.ui.LoadingDialog');
+goog.require('wtf.app.ui.UrlLoaderEntry');
+goog.require('wtf.app.ui.XhrLoaderEntry');
+goog.require('wtf.db.DataSourceInfo');
+goog.require('wtf.doc.Document');
+goog.require('wtf.io');
+goog.require('wtf.io.drive');
+goog.require('wtf.pal');
+goog.require('wtf.timing');
+goog.require('wtf.ui.ErrorDialog');
+
+
+
+/**
+ * Handles all trace loading behavior.
+ * @param {!wtf.app.ui.MainDisplay} mainDisplay Main display.
+ * @constructor
+ * @extends {goog.Disposable}
+ */
+wtf.app.ui.Loader = function(mainDisplay) {
+  goog.base(this);
+
+  /**
+   * DOM helper.
+   * @type {!goog.dom.DomHelper}
+   * @private
+   */
+  this.dom_ = mainDisplay.getDom();
+
+  /**
+   * Owning main display.
+   * @type {!wtf.app.ui.MainDisplay}
+   * @private
+   */
+  this.mainDisplay_ = mainDisplay;
+
+  /**
+   * Loading dialog, if it is displayed.
+   * @type {wtf.app.ui.LoadingDialog}
+   * @private
+   */
+  this.progressDialog_ = null;
+
+  if (wtf.io.drive.isSupported()) {
+    wtf.io.drive.prepare();
+  }
+};
+goog.inherits(wtf.app.ui.Loader, goog.Disposable);
+
+
+/**
+ * @override
+ */
+wtf.app.ui.Loader.prototype.disposeInternal = function() {
+  // TODO(benvanik): abort any inprogress loads.
+  goog.dispose(this.progressDialog_);
+  goog.base(this, 'disposeInternal');
+};
+
+
+/**
+ * Calculates a title name from the given entries.
+ * @param {!Array.<!wtf.app.ui.LoaderEntry>} entries Entries.
+ * @private
+ */
+wtf.app.ui.Loader.prototype.generateTitleFromEntries_ = function(entries) {
+  var title = '';
+  for (var n = 0; n < entries.length; n++) {
+    var sourceInfo = entries[n].getSourceInfo();
+    var filename = sourceInfo.filename;
+    var lastSlash = filename.lastIndexOf('/');
+    if (lastSlash != -1) {
+      filename = filename.substr(lastSlash + 1);
+    }
+    title += filename;
+  }
+  return title;
+};
+
+
+/**
+ * Attempts to guess the content type of the file entry by filename.
+ * @param {string} filename Filename (or URL).
+ * @return {string} Content type.
+ * @private
+ */
+wtf.app.ui.Loader.prototype.inferContentType_ = function(filename) {
+  if (goog.string.endsWith(filename, '.wtf-trace') ||
+      goog.string.endsWith(filename, '.bin.part')) {
+    return 'application/x-extension-wtf-trace';
+  } else if (goog.string.endsWith(filename, '.wtf-json')) {
+    return 'application/x-extension-wtf-json';
+  } else if (goog.string.endsWith(filename, '.wtf-calls')) {
+    return 'application/x-extension-wtf-calls';
+  }
+  // Default. Maybe we should just return null.
+  return 'application/x-extension-wtf-trace';
+};
+
+
+/**
+ * Begins loading snapshot data from an incoming IPC command.
+ * See the extension.js file in the injector for details about the command.
+ * @param {!Object} data Command data.
+ */
+wtf.app.ui.Loader.prototype.loadSnapshot = function(data) {
+  var revokeBlobUrls = data['revoke_blob_urls'] || false;
+  var contentLength = data['content_length'];
+  _gaq.push(['_trackEvent', 'app', 'open_snapshot', null, contentLength]);
+
+  // Build entries.
+  // Note that the command may contain either buffers or URLs.
+  var contentTypes = data['content_types'];
+  var contentSources = data['content_sources'];
+  var contentBuffers = data['content_buffers'];
+  var contentUrls = data['content_urls'];
+  goog.asserts.assert(contentTypes.length == contentSources.length);
+  var entries = [];
+  for (var n = 0; n < contentTypes.length; n++) {
+    var sourceInfo = new wtf.db.DataSourceInfo(
+        contentSources[n], contentTypes[n]);
+    var entry = null;
+    if (contentBuffers) {
+      // Incoming arrays may be in many forms.
+      // We may want to check content type and only string->[] if it's actually
+      // encoded binary.
+      var buffer = null;
+      if (goog.isArray(contentBuffers[n])) {
+        buffer = wtf.io.createByteArrayFromArray(contentBuffers[n]);
+      } else if (goog.isString(contentBuffers[n])) {
+        buffer = wtf.io.stringToNewByteArray(contentBuffers[n]);
+      } else {
+        buffer = contentBuffers[n];
+      }
+      entry = new wtf.app.ui.BufferLoaderEntry(sourceInfo, buffer);
+    } else {
+      entry = new wtf.app.ui.UrlLoaderEntry(
+          sourceInfo, contentUrls[n], revokeBlobUrls);
+    }
+    entries.push(entry);
+  }
+
+  this.loadEntries_(entries);
+};
+
+
+/**
+ * Requests a local open dialog.
+ * The user may cancel the dialog, in which case no load will occur.
+ * @param {function(this:T)=} opt_selectCallback Function to call when a
+ *     file is selected. There's no cancellation notice.
+ * @param {T=} opt_scope Callback scope.
+ * @template T
+ */
+wtf.app.ui.Loader.prototype.requestLocalOpenDialog = function(
+    opt_selectCallback, opt_scope) {
+  var inputElement = this.dom_.createElement(goog.dom.TagName.INPUT);
+  inputElement['type'] = 'file';
+  inputElement['multiple'] = true;
+  inputElement['accept'] = [
+    '.wtf-trace,application/x-extension-wtf-trace',
+    '.wtf-json,application/x-extension-wtf-json',
+    '.wtf-calls,application/x-extension-wtf-calls',
+    '.part,application/x-extension-part'
+  ].join(',');
+  inputElement.click();
+  goog.events.listenOnce(inputElement, goog.events.EventType.CHANGE,
+      function(e) {
+        if (opt_selectCallback) {
+          opt_selectCallback.call(opt_scope);
+        }
+        _gaq.push(['_trackEvent', 'app', 'open_local_files']);
+        this.loadFiles(inputElement.files);
+      }, false, this);
+};
+
+
+/**
+ * Requests a Drive open dialog.
+ * The user may cancel the dialog, in which case no load will occur.
+ * @param {function(this:T)=} opt_cancelCallback Function to call when the
+ *     dialog is cancelled by the user.
+ * @param {T=} opt_scope Callback scope.
+ * @template T
+ */
+wtf.app.ui.Loader.prototype.requestDriveOpenDialog = function(
+    opt_cancelCallback, opt_scope) {
+  if (!wtf.io.drive.isSupported()) {
+    wtf.ui.ErrorDialog.show(
+        'Drive support not enabled',
+        'Drive is not supported in this build.',
+        this.dom_);
+    if (opt_cancelCallback) {
+      opt_cancelCallback.call(opt_scope);
+    }
+    return;
+  }
+
+  goog.result.wait(wtf.io.drive.showFilePicker({
+    title: 'Select a trace file'
+  }), function(filesResult) {
+    var files = /** @type {Array.<!File>} */ (filesResult.getValue());
+    if (!files || !files.length) {
+      // Cancelled.
+      if (opt_cancelCallback) {
+        opt_cancelCallback.call(opt_scope);
+      }
+      return;
+    }
+
+    _gaq.push(['_trackEvent', 'app', 'open_drive_files']);
+
+    var entries = [];
+    var errors = [];
+    var remaining = files.length;
+    goog.array.forEach(files, function(file) {
+      var filename = file[0];
+      var fileId = file[1];
+      var contentType = this.inferContentType_(filename);
+      var sourceInfo = new wtf.db.DataSourceInfo(filename, contentType);
+
+      // This call will kick off a bunch of API calls to get file metadata/etc.
+      // Afterwards, it'll give us a DriveFile that has a pending XHR and the
+      // information.
+      goog.result.wait(wtf.io.drive.downloadFile(fileId), function(result) {
+        remaining--;
+        var driveFile = result.getValue();
+        if (driveFile) {
+          // The filename may differ from the other, due to the horrible Drive
+          // API.
+          sourceInfo.filename = driveFile.filename;
+
+          // Set the pending XHR.
+          var entry = new wtf.app.ui.XhrLoaderEntry(sourceInfo, driveFile.xhr);
+          entries.push(entry);
+        } else {
+          errors.push(result.getError());
+        }
+        if (!remaining) {
+          finished.call(this);
+        }
+      }, this);
+    }, this);
+
+    /**
+     * @this {wtf.app.ui.Loader}
+     */
+    function finished() {
+      if (errors.length) {
+        // TODO(benvanik): log errors?
+        this.loadFailed_(
+            'Unable to load files',
+            'An error occurred while trying to fetch a file from Drive.');
+        return;
+      }
+
+      this.loadEntries_(entries);
+    };
+  }, this);
+};
+
+
+/**
+ * Begins loading a set of HTML5 File objects.
+ * These can be from the filesystem, dragged in, etc.
+ * @param {!Array.<!File>} files File objects.
+ */
+wtf.app.ui.Loader.prototype.loadFiles = function(files) {
+  var entries = [];
+  for (var n = 0; n < files.length; n++) {
+    var filename = files[n].name;
+    var contentType = this.inferContentType_(filename);
+    var sourceInfo = new wtf.db.DataSourceInfo(filename, contentType);
+    var entry = new wtf.app.ui.FileLoaderEntry(sourceInfo, files[n]);
+    entries.push(entry);
+  }
+  this.loadEntries_(entries);
+};
+
+
+/**
+ * Begins loading a set of files from URLs.
+ * @param {!Array.<string>} urls URLs.
+ */
+wtf.app.ui.Loader.prototype.loadUrls = function(urls) {
+  var entries = [];
+  for (var n = 0; n < urls.length; n++) {
+    var url = urls[n];
+    var contentType = this.inferContentType_(url);
+    var sourceInfo = new wtf.db.DataSourceInfo(url, contentType);
+    var entry = new wtf.app.ui.UrlLoaderEntry(sourceInfo, url, true);
+    entries.push(entry);
+  }
+  this.loadEntries_(entries);
+};
+
+
+/**
+ * Begins loading the entries and handles their async completion.
+ * @param {!Array.<!wtf.app.ui.LoaderEntry>} entries Loader entries.
+ * @param {string=} opt_title Optional override for the app title. If omitted
+ *     the title will be inferred from the entries.
+ * @private
+ */
+wtf.app.ui.Loader.prototype.loadEntries_ = function(entries, opt_title) {
+  // Close the old document.
+  this.mainDisplay_.setDocumentView(null, true);
+
+  // TODO(benvanik): avoid showing the loading dialog for small traces.
+
+  // Show the loading dialog.
+  // Don't registerDisposable it so that we don't leak it.
+  goog.asserts.assert(!this.progressDialog_);
+  var body = this.dom_.getDocument().body;
+  goog.asserts.assert(body);
+  this.progressDialog_ = new wtf.app.ui.LoadingDialog(body, entries, this.dom_);
+
+  // Wait until the dialog is displayed.
+  wtf.timing.setTimeout(218, function() {
+    // Gather all deferrreds and wait on them.
+    var deferreds = goog.array.map(entries, function(entry) {
+      return entry.begin();
+    });
+    goog.async.DeferredList.gatherResults(deferreds).addCallbacks(
+        function() {
+          this.loadSucceeded_(entries, opt_title);
+        },
+        function(args) {
+          this.loadFailed_(
+              'Unable to load snapshot',
+              'Source files could not be fetched.');
+        }, this);
+  }, this);
+};
+
+
+/**
+ * Handles successful loads.
+ * @param {!Array.<!wtf.app.ui.LoaderEntry>} entries Loader entries.
+ * @param {string=} opt_title Optional override for the app title. If omitted
+ *     the title will be inferred from the entries.
+ * @private
+ */
+wtf.app.ui.Loader.prototype.loadSucceeded_ = function(entries, opt_title) {
+  // Create the document.
+  var doc = new wtf.doc.Document(wtf.pal.getPlatform());
+  var db = doc.getDatabase();
+
+  // Add the data sources.
+  // This will often queue a bunch of invalidates for the next tick.
+  var contentLength = 0;
+  for (var n = 0; n < entries.length; n++) {
+    var entry = entries[n];
+    contentLength += this.addEntryToDatabase_(entries[n], db);
+
+    // TODO(benvanik): retain for a bit?
+    goog.dispose(entry);
+  }
+  _gaq.push(['_trackEvent', 'app', 'open_files', null, contentLength]);
+
+  // Pick a title, unless one was specified.
+  var title = opt_title || this.generateTitleFromEntries_(entries);
+  this.mainDisplay_.setTitle(title);
+
+  // Close the progress dialog.
+  if (this.progressDialog_) {
+    this.progressDialog_.close(finishLoad, this);
+  } else {
+    finishLoad.call(this);
+  }
+  this.progressDialog_ = null;
+
+  // This is called after the dialog has closed to give it a chance to animate
+  // out.
+  function finishLoad() {
+    // Show the document.
+    var documentView = this.mainDisplay_.openDocument(doc);
+    goog.asserts.assert(documentView);
+
+    // Zoom to fit.
+    // TODO(benvanik): remove setTimeout when zoomToFit is based on view
+    wtf.timing.setTimeout(50, function() {
+      documentView.zoomToFit();
+    }, this);
+  };
+};
+
+
+/**
+ * Adds an entry to the database by guessing its type.
+ * @param {!wtf.app.ui.LoaderEntry} entry Entry to add.
+ * @param {!wtf.db.Database} db Target database.
+ * @return {number} The total size, in bytes, of the data (estimated).
+ * @private
+ */
+wtf.app.ui.Loader.prototype.addEntryToDatabase_ = function(entry, db) {
+  var sourceInfo = entry.getSourceInfo();
+  var data = entry.getContents();
+  goog.asserts.assert(data);
+  if (!data) {
+    return 0;
+  }
+
+  // Wrap array buffers so they are always wtf.io.ByteArray-like.
+  if (data instanceof ArrayBuffer) {
+    data = new Uint8Array(data);
+  }
+
+  // Here be heuristics.
+  // If we have a mime type, use that. Otherwise try to guess based on the entry
+  // data type.
+  // TODO(benvanik): sniff contents/don't rely on mime type/etc.
+  switch (sourceInfo.contentType) {
+    case 'application/x-extension-wtf-trace':
+      goog.asserts.assert(wtf.io.isByteArray(data));
+      db.addBinarySource(/** @type {!wtf.io.ByteArray} */ (data), sourceInfo);
+      return data.length;
+    case 'application/x-extension-wtf-json':
+      db.addJsonSource(data, sourceInfo);
+      return goog.isString(data) ? data.length : 0;
+    case 'application/x-extension-wtf-calls':
+      goog.asserts.assert(wtf.io.isByteArray(data));
+      db.addCallsSource(/** @type {!wtf.io.ByteArray} */ (data), sourceInfo);
+      return data.length;
+  }
+
+  // Fallback to always trying wtf-trace.
+  if (wtf.io.isByteArray(data)) {
+    db.addBinarySource(/** @type {!wtf.io.ByteArray} */ (data), sourceInfo);
+    return data.length;
+  }
+  goog.asserts.assert('Unrecognized entry data type - ignoring.');
+  goog.global.console.log('Unrecognized entry data type ' +
+      sourceInfo.contentType + ' - ignoring.');
+  return 0;
+};
+
+
+/**
+ * Handles load failures.
+ * @param {string} title Error title.
+ * @param {string} message Error message/details.
+ * @private
+ */
+wtf.app.ui.Loader.prototype.loadFailed_ = function(title, message) {
+  _gaq.push(['_trackEvent', 'app', 'load_failed', title]);
+
+  // Close the progress dialog.
+  goog.dispose(this.progressDialog_);
+  this.progressDialog_ = null;
+
+  // Let them know we failed.
+  wtf.ui.ErrorDialog.show(title, message, this.dom_);
+};

--- a/src/wtf/app/ui/loaderentry.js
+++ b/src/wtf/app/ui/loaderentry.js
@@ -1,0 +1,362 @@
+/**
+ * Copyright 2013 Google, Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+/**
+ * @fileoverview Loader support type for tracking loads.
+ *
+ * @author benvanik@google.com (Ben Vanik)
+ */
+
+goog.provide('wtf.app.ui.BufferLoaderEntry');
+goog.provide('wtf.app.ui.FileLoaderEntry');
+goog.provide('wtf.app.ui.LoaderEntry');
+goog.provide('wtf.app.ui.UrlLoaderEntry');
+goog.provide('wtf.app.ui.XhrLoaderEntry');
+
+goog.require('goog.async.Deferred');
+goog.require('goog.events');
+goog.require('goog.events.EventHandler');
+goog.require('goog.fs');
+goog.require('goog.fs.Error');
+goog.require('goog.fs.FileReader');
+goog.require('goog.net.HttpStatus');
+goog.require('goog.net.XmlHttp');
+goog.require('goog.string');
+goog.require('wtf.events.EventEmitter');
+
+
+
+/**
+ * Loader entry.
+ * Used to track the progress of an individual entry in the loader.
+ * @param {!wtf.db.DataSourceInfo} sourceInfo Source information.
+ * @constructor
+ * @extends {wtf.events.EventEmitter}
+ */
+wtf.app.ui.LoaderEntry = function(sourceInfo) {
+  goog.base(this);
+
+  /**
+   * Source information.
+   * @type {!wtf.db.DataSourceInfo}
+   * @private
+   */
+  this.sourceInfo_ = sourceInfo;
+
+  /**
+   * The contents of the entry.
+   * This is only set once the load has completed.
+   * @type {wtf.app.ui.LoaderEntry.ContentType}
+   * @private
+   */
+  this.contents_ = null;
+
+  /**
+   * If an async fetch is required this will be a deferred waiting on its
+   * completion.
+   * @type {!goog.async.Deferred}
+   * @private
+   */
+  this.deferred_ = new goog.async.Deferred();
+};
+goog.inherits(wtf.app.ui.LoaderEntry, wtf.events.EventEmitter);
+
+
+/**
+ * @typedef {wtf.io.ByteArray|ArrayBuffer|ArrayBufferView|string}
+ */
+wtf.app.ui.LoaderEntry.ContentType;
+
+
+/**
+ * @enum {string}
+ */
+wtf.app.ui.LoaderEntry.EventType = {
+  PROGRESS: goog.events.getUniqueId('progress')
+};
+
+
+/**
+ * Gets the source information for the entry.
+ * @return {!wtf.db.DataSourceInfo} Data source information.
+ */
+wtf.app.ui.LoaderEntry.prototype.getSourceInfo = function() {
+  return this.sourceInfo_;
+};
+
+
+/**
+ * Begins the load of the entry, if it is async.
+ * @return {!goog.async.Deferred} A deferred fulfilled when the load completes.
+ */
+wtf.app.ui.LoaderEntry.prototype.begin = function() {
+  return this.deferred_;
+};
+
+
+/**
+ * Fires a progress event.
+ * @param {number} loaded Loaded amount, in bytes.
+ * @param {number} total Total amount, in bytes.
+ * @protected
+ */
+wtf.app.ui.LoaderEntry.prototype.fireProgressEvent = function(loaded, total) {
+  this.emitEvent(wtf.app.ui.LoaderEntry.EventType.PROGRESS, loaded, total);
+};
+
+
+/**
+ * Gets the result contents.
+ * The result is only valid if the loader completed successfully.
+ * @return {wtf.app.ui.LoaderEntry.ContentType} Contents.
+ */
+wtf.app.ui.LoaderEntry.prototype.getContents = function() {
+  return this.contents_;
+};
+
+
+/**
+ * Sets the result contents.
+ * This is an implicit success and will fire the deferred.
+ * @param {!wtf.app.ui.LoaderEntry.ContentType} contents Contents.
+ * @protected
+ */
+wtf.app.ui.LoaderEntry.prototype.setContents = function(contents) {
+  this.contents_ = contents;
+  this.deferred_.callback(null);
+};
+
+
+/**
+ * Sets the error message.
+ * This is an implicit failure and will fire the deferred.
+ * @param {string=} opt_message Error message/status code.
+ * @protected
+ */
+wtf.app.ui.LoaderEntry.prototype.setError = function(opt_message) {
+  this.deferred_.errback(opt_message);
+};
+
+
+
+/**
+ * A static loader entry initialized with a buffer.
+ * @param {!wtf.db.DataSourceInfo} sourceInfo Source information.
+ * @param {!wtf.io.ByteArray} buffer Buffer.
+ * @constructor
+ * @extends {wtf.app.ui.LoaderEntry}
+ */
+wtf.app.ui.BufferLoaderEntry = function(sourceInfo, buffer) {
+  goog.base(this, sourceInfo);
+
+  // Succeed immediately.
+  this.setContents(buffer);
+};
+goog.inherits(wtf.app.ui.BufferLoaderEntry, wtf.app.ui.LoaderEntry);
+
+
+
+/**
+ * A URL-based loader entry.
+ * The given XHR should not have had its send method called yet.
+ * @param {!wtf.db.DataSourceInfo} sourceInfo Source information.
+ * @param {!XMLHttpRequest} xhr XHR to begin loading.
+ * @constructor
+ * @extends {wtf.app.ui.LoaderEntry}
+ */
+wtf.app.ui.XhrLoaderEntry = function(sourceInfo, xhr) {
+  goog.base(this, sourceInfo);
+
+  /**
+   * Event handler.
+   * @type {!goog.events.EventHandler}
+   * @private
+   */
+  this.eh_ = new goog.events.EventHandler(this);
+  this.registerDisposable(this.eh_);
+
+  /**
+   * The XHR to fetch.
+   * @type {!XMLHttpRequest}
+   * @private
+   */
+  this.xhr_ = xhr;
+};
+goog.inherits(wtf.app.ui.XhrLoaderEntry, wtf.app.ui.LoaderEntry);
+
+
+/**
+ * @override
+ */
+wtf.app.ui.XhrLoaderEntry.prototype.begin = function() {
+  var eh = this.eh_;
+  var xhr = this.xhr_;
+
+  // Set response mode. Must be set before send().
+  var asBinary = this.getSourceInfo().isBinary();
+  xhr.responseType = asBinary ? 'arraybuffer' : 'text';
+
+  // Fired zero-to-many times.
+  eh.listen(xhr, goog.fs.FileReader.EventType.PROGRESS, function(e) {
+    e = e.getBrowserEvent();
+    if (e.lengthComputable) {
+      this.fireProgressEvent(e.loaded, e.total);
+    }
+  });
+
+  // Always fired after load/abort/error.
+  eh.listen(xhr, goog.fs.FileReader.EventType.LOAD_END, function(e) {
+    var status = -1;
+    var statusText = '';
+    if (xhr.readyState == goog.net.XmlHttp.ReadyState.COMPLETE) {
+      status = xhr.status;
+      statusText = xhr.statusText;
+    }
+    if (goog.net.HttpStatus.isSuccess(status)) {
+      // Succeeded.
+      var length = xhr.response.length || xhr.response.byteLength;
+      this.fireProgressEvent(length, length);
+      this.setContents(xhr.response);
+    } else {
+      // Failed.
+      this.setError(status + ' ' + statusText);
+    }
+  });
+
+  // NOTE: once send is called we cannot add any more progress events/etc.
+  xhr.send();
+
+  return goog.base(this, 'begin');
+};
+
+
+
+/**
+ * A URL-based loader entry.
+ * The given XHR should not have had its send method called yet.
+ * @param {!wtf.db.DataSourceInfo} sourceInfo Source information.
+ * @param {string} url URL to fetch.
+ * @param {boolean} revokeWhenDone Revoke blob: URLs when done.
+ * @constructor
+ * @extends {wtf.app.ui.XhrLoaderEntry}
+ */
+wtf.app.ui.UrlLoaderEntry = function(sourceInfo, url, revokeWhenDone) {
+  var xhr = new XMLHttpRequest();
+  xhr.open('GET', url, true);
+  goog.base(this, sourceInfo, xhr);
+
+  /**
+   * Source URL.
+   * @type {string}
+   * @private
+   */
+  this.url_ = url;
+
+  /**
+   * Revoke blob: URls when done with them.
+   * @type {boolean}
+   * @private
+   */
+  this.revokeWhenDone_ = revokeWhenDone;
+};
+goog.inherits(wtf.app.ui.UrlLoaderEntry, wtf.app.ui.XhrLoaderEntry);
+
+
+/**
+ * @override
+ */
+wtf.app.ui.UrlLoaderEntry.prototype.disposeInternal = function() {
+  if (this.revokeWhenDone_ &&
+      goog.string.startsWith(this.url_, 'blob:')) {
+    // Revoke blob URLs, if we were asked to.
+    goog.fs.revokeObjectUrl(this.url_);
+  }
+  goog.base(this, 'disposeInternal');
+};
+
+
+
+/**
+ * An HTML File-based loader entry.
+ * @param {!wtf.db.DataSourceInfo} sourceInfo Source information.
+ * @param {!File} file File to load.
+ * @constructor
+ * @extends {wtf.app.ui.LoaderEntry}
+ */
+wtf.app.ui.FileLoaderEntry = function(sourceInfo, file) {
+  goog.base(this, sourceInfo);
+
+  /**
+   * Event handler.
+   * @type {!goog.events.EventHandler}
+   * @private
+   */
+  this.eh_ = new goog.events.EventHandler(this);
+  this.registerDisposable(this.eh_);
+
+  /**
+   * The File to fetch.
+   * @type {!File}
+   * @private
+   */
+  this.file_ = file;
+};
+goog.inherits(wtf.app.ui.FileLoaderEntry, wtf.app.ui.LoaderEntry);
+
+
+/**
+ * @override
+ */
+wtf.app.ui.FileLoaderEntry.prototype.disposeInternal = function() {
+  // close() was added later - check for its existence.
+  if (this.file_['close']) {
+    this.file_['close']();
+  }
+  goog.base(this, 'disposeInternal');
+};
+
+
+/**
+ * @override
+ */
+wtf.app.ui.FileLoaderEntry.prototype.begin = function() {
+  var eh = this.eh_;
+
+  var reader = new FileReader();
+
+  // Fired zero-to-many times.
+  eh.listen(reader, goog.fs.FileReader.EventType.PROGRESS, function(e) {
+    e = e.getBrowserEvent();
+    if (e.lengthComputable) {
+      this.fireProgressEvent(e.loaded, e.total);
+    }
+  });
+
+  // Always fired after load/abort/error.
+  eh.listen(reader, goog.fs.FileReader.EventType.LOAD_END, function(e) {
+    e = e.getBrowserEvent();
+    this.fireProgressEvent(e.loaded, e.loaded);
+
+    if (reader.result) {
+      // Succeeded.
+      this.setContents(reader.result);
+    } else {
+      // Failed.
+      this.setError(goog.fs.Error.getDebugMessage(
+          /** @type {number} */ (reader.error)));
+    }
+  });
+
+  var asBinary = this.getSourceInfo().isBinary();
+  if (asBinary) {
+    reader.readAsArrayBuffer(this.file_);
+  } else {
+    reader.readAsText(this.file_);
+  }
+
+  return goog.base(this, 'begin');
+};

--- a/src/wtf/app/ui/loadingdialog.js
+++ b/src/wtf/app/ui/loadingdialog.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2013 Google, Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+/**
+ * @fileoverview Loading dialog screen.
+ *
+ * @author benvanik@google.com (Ben Vanik)
+ */
+
+goog.provide('wtf.app.ui.LoadingDialog');
+
+goog.require('goog.soy');
+goog.require('goog.style');
+goog.require('wtf.app.ui.LoaderEntry');
+goog.require('wtf.app.ui.loadingdialog');
+goog.require('wtf.ui.Dialog');
+
+
+
+/**
+ * Loading overlay screen.
+ *
+ * @param {!Element} parentElement Element to display in.
+ * @param {!Array.<!wtf.app.ui.LoaderEntry>} entries Loader entries.
+ * @param {goog.dom.DomHelper=} opt_dom DOM helper.
+ * @constructor
+ * @extends {wtf.ui.Dialog}
+ */
+wtf.app.ui.LoadingDialog = function(parentElement, entries, opt_dom) {
+  goog.base(this, {
+    modal: true,
+    clickToClose: false
+  }, parentElement, opt_dom);
+
+  for (var n = 0; n < entries.length; n++) {
+    this.addEntryRow_(entries[n]);
+  }
+  this.center();
+};
+goog.inherits(wtf.app.ui.LoadingDialog, wtf.ui.Dialog);
+
+
+/**
+ * @override
+ */
+wtf.app.ui.LoadingDialog.prototype.createDom = function(dom) {
+  return /** @type {!Element} */ (goog.soy.renderAsFragment(
+      wtf.app.ui.loadingdialog.control, {
+      }, undefined, dom));
+};
+
+
+/**
+ * Adds a progress row for a loader entry.
+ * @param {!wtf.app.ui.LoaderEntry} entry Loader entry.
+ * @private
+ */
+wtf.app.ui.LoadingDialog.prototype.addEntryRow_ = function(entry) {
+  var dom = this.getDom();
+
+  var sourceInfo = entry.getSourceInfo();
+
+  var el = /** @type {!Element} */ (goog.soy.renderAsFragment(
+      wtf.app.ui.loadingdialog.entry, {
+        filename: sourceInfo.filename
+      }, undefined, dom));
+  dom.appendChild(this.getChildElement(goog.getCssName('list')), el);
+
+  var progressTrackEl = this.getChildElement(
+      goog.getCssName('track'), el);
+  var progressTextEl = this.getChildElement(
+      goog.getCssName('percentComplete'), el);
+  entry.addListener(wtf.app.ui.LoaderEntry.EventType.PROGRESS,
+      function(loaded, total) {
+        var percent = Math.floor(loaded / total * 100);
+        goog.style.setWidth(progressTrackEl, percent + '%');
+        dom.setTextContent(progressTextEl, String(percent));
+      }, this);
+};

--- a/src/wtf/app/ui/loadingdialog.less
+++ b/src/wtf/app/ui/loadingdialog.less
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2013 Google, Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+/**
+ * Loading dialog CSS.
+ *
+ * @author benvanik@google.com (Ben Vanik)
+ */
+
+.appUiLoadingDialog {
+  width: 450px;
+  margin: 10px;
+
+  .filename {
+    max-width: 324px;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    line-height: 18px;
+  }
+
+  .list {
+    margin-top: 25px;
+    margin-bottom: 35px;
+  }
+
+  .progress {
+    left: 50%;
+    position: relative;
+    margin-left: -170px;
+    margin-top: 15px;
+  }
+}

--- a/src/wtf/app/ui/loadingdialog.soy
+++ b/src/wtf/app/ui/loadingdialog.soy
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2013 Google, Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+/**
+ * Loading dialog DOM.
+ *
+ * @author benvanik@google.com (Ben Vanik)
+ */
+
+{namespace wtf.app.ui.loadingdialog}
+
+
+/**
+ * Root control UI.
+ */
+{template .control}
+  <div class="{css appUiLoadingDialog}">
+    <h1 class="{css kRedLink}">
+      Loading trace...
+    </h1>
+    <div class="{css list}">
+    </div>
+  </div>
+{/template}
+
+
+/**
+ * Entry template.
+ * @param filename Filename.
+ */
+{template .entry}
+  <div class="{css progress}">
+    {if $filename}
+      <div class="{css filename} {css kSecondaryText}">{$filename}</div>
+    {/if}
+    <div class="{css kProgressBar}">
+      <div class="{css track} {css blue}"></div>
+    </div>
+    <p class="{css kProgressText}"><span class="{css percentComplete}">0</span>% complete.</p>
+  </div>
+{/template}

--- a/src/wtf/app/ui/maindisplay.js
+++ b/src/wtf/app/ui/maindisplay.js
@@ -16,36 +16,21 @@ goog.provide('wtf.app.ui.MainDisplay');
 goog.require('goog.Uri');
 goog.require('goog.array');
 goog.require('goog.asserts');
-goog.require('goog.async.Deferred');
-goog.require('goog.async.DeferredList');
 goog.require('goog.dom');
-goog.require('goog.dom.TagName');
-goog.require('goog.events');
 goog.require('goog.events.EventType');
-goog.require('goog.fs.FileReader');
-goog.require('goog.net.EventType');
-goog.require('goog.net.XhrIo');
-goog.require('goog.result');
 goog.require('goog.soy');
-goog.require('goog.string');
 goog.require('wtf.app.ui.DocumentView');
 goog.require('wtf.app.ui.HelpDialog');
+goog.require('wtf.app.ui.Loader');
 goog.require('wtf.app.ui.SplashDialog');
 goog.require('wtf.app.ui.maindisplay');
 goog.require('wtf.doc.Document');
-goog.require('wtf.events');
 goog.require('wtf.events.CommandManager');
-goog.require('wtf.events.KeyboardScope');
 goog.require('wtf.ext');
-goog.require('wtf.io');
-goog.require('wtf.io.drive');
 goog.require('wtf.ipc');
 goog.require('wtf.ipc.Channel');
-goog.require('wtf.pal');
-goog.require('wtf.timing');
 goog.require('wtf.ui.Control');
 goog.require('wtf.ui.Dialog');
-goog.require('wtf.ui.ErrorDialog');
 goog.require('wtf.ui.SettingsDialog');
 
 
@@ -105,6 +90,14 @@ wtf.app.ui.MainDisplay = function(
   this.documentView_ = null;
 
   /**
+   * Tracing loading utility.
+   * @type {!wtf.app.ui.Loader}
+   * @private
+   */
+  this.loader_ = new wtf.app.ui.Loader(this);
+  this.registerDisposable(this.loader_);
+
+  /**
    * Parent window channel, if one exists.
    * @type {wtf.ipc.Channel}
    * @private
@@ -121,29 +114,14 @@ wtf.app.ui.MainDisplay = function(
 
   // Setup command manager.
   this.commandManager_.registerSimpleCommand(
-      'open_trace', this.requestTraceLoad, this);
+      'open_local_trace', this.requestLocalTraceLoad, this);
   this.commandManager_.registerSimpleCommand(
       'open_drive_trace', this.requestDriveTraceLoad, this);
-  this.commandManager_.registerSimpleCommand(
-      'save_trace', this.saveTrace_, this);
-  this.commandManager_.registerSimpleCommand(
-      'save_drive_trace', this.saveDriveTrace_, this);
   this.commandManager_.registerSimpleCommand(
       'show_settings', this.showSettings_, this);
   this.commandManager_.registerSimpleCommand(
       'toggle_help', this.toggleHelpDialog_, this);
 
-  // Setup keyboard shortcuts.
-  var keyboard = wtf.events.getWindowKeyboard(dom);
-  var keyboardScope = new wtf.events.KeyboardScope(keyboard);
-  this.registerDisposable(keyboardScope);
-  keyboardScope.addCommandShortcut('command+o', 'open_trace');
-  keyboardScope.addCommandShortcut('command+s', 'save_trace');
-  keyboardScope.addCommandShortcut('shift+/', 'toggle_help');
-
-  if (wtf.io.drive.isSupported()) {
-    wtf.io.drive.prepare();
-  }
   this.setupDragDropLoading_();
 
   // Look for launch arguments.
@@ -156,7 +134,7 @@ wtf.app.ui.MainDisplay = function(
     var urls = queryData.get('url');
     if (urls && urls.length) {
       _gaq.push(['_trackEvent', 'app', 'open_querystring_files']);
-      this.loadNetworkTraces(urls.split(','));
+      this.loader_.loadUrls(urls.split(','));
       startupLoad = true;
     }
   } else if (queryData.containsKey('expect_data')) {
@@ -228,9 +206,12 @@ wtf.app.ui.MainDisplay.prototype.setupDragDropLoading_ = function() {
       e.stopPropagation();
       e.preventDefault();
 
+      // Hide the splash dialog if it's up.
+      this.showSplashDialog_(false);
+
       _gaq.push(['_trackEvent', 'app', 'open_drag_files']);
 
-      this.loadTraceFiles(browserEvent.dataTransfer.files);
+      this.loader_.loadFiles(browserEvent.dataTransfer.files);
     }
   }, false, this);
 };
@@ -240,9 +221,8 @@ wtf.app.ui.MainDisplay.prototype.setupDragDropLoading_ = function() {
  * Sets the title of the tab.
  * This portion is used as the suffix after the application name.
  * @param {string?} value New value, or null to clear.
- * @private
  */
-wtf.app.ui.MainDisplay.prototype.setTitle_ = function(value) {
+wtf.app.ui.MainDisplay.prototype.setTitle = function(value) {
   var title = 'Web Tracing Framework';
   if (!COMPILED) {
     title += ' (DEBUG)';
@@ -252,25 +232,6 @@ wtf.app.ui.MainDisplay.prototype.setTitle_ = function(value) {
   }
   var doc = this.getDom().getDocument();
   doc.title = title;
-};
-
-
-/**
- * Sets the title of the tab from the given filenames.
- * @param {!Array.<string>} filenames A list of filenames (paths/URLs allowed).
- * @private
- */
-wtf.app.ui.MainDisplay.prototype.setTitleFromFilenames_ = function(filenames) {
-  var title = '';
-  for (var n = 0; n < filenames.length; n++) {
-    var filename = filenames[n];
-    var lastSlash = filename.lastIndexOf('/');
-    if (lastSlash != -1) {
-      filename = filename.substr(lastSlash + 1);
-    }
-    title += filename;
-  }
-  this.setTitle_(title);
 };
 
 
@@ -286,8 +247,11 @@ wtf.app.ui.MainDisplay.prototype.getDocumentView = function() {
 /**
  * Sets the active document view, disposing any previous one.
  * @param {wtf.app.ui.DocumentView} documentView New document view.
+ * @param {boolean=} opt_preventSplash True to prevent the splash screen from
+ *     being shown.
  */
-wtf.app.ui.MainDisplay.prototype.setDocumentView = function(documentView) {
+wtf.app.ui.MainDisplay.prototype.setDocumentView = function(documentView,
+    opt_preventSplash) {
   if (this.documentView_ == documentView) {
     return;
   }
@@ -296,13 +260,15 @@ wtf.app.ui.MainDisplay.prototype.setDocumentView = function(documentView) {
   this.documentView_ = null;
 
   // Show the splash dialog if needed.
-  this.showSplashDialog_(!documentView);
+  if (!opt_preventSplash) {
+    this.showSplashDialog_(!documentView);
+  }
 
   if (documentView) {
     // TODO(benvanik): notify of change?
     this.documentView_ = documentView;
   } else {
-    this.setTitle_(null);
+    this.setTitle(null);
   }
 };
 
@@ -310,16 +276,17 @@ wtf.app.ui.MainDisplay.prototype.setDocumentView = function(documentView) {
 /**
  * Sets up a new document view for the given document and switches to it.
  * @param {!wtf.doc.Document} doc Document.
+ * @return {!wtf.app.ui.DocumentView} The new document view.
  */
 wtf.app.ui.MainDisplay.prototype.openDocument = function(doc) {
   _gaq.push(['_trackEvent', 'app', 'open_document']);
 
-  this.setDocumentView(null);
   var documentView = new wtf.app.ui.DocumentView(
       this.getChildElement(goog.getCssName('appUiMainDocumentView')),
       this.getDom(),
       doc);
   this.setDocumentView(documentView);
+  return documentView;
 };
 
 
@@ -349,82 +316,7 @@ wtf.app.ui.MainDisplay.prototype.channelMessage_ = function(data) {
  * @private
  */
 wtf.app.ui.MainDisplay.prototype.handleSnapshotCommand_ = function(data) {
-  var contentType = data['content_type'];
-  var contentLength = data['content_length'];
-  _gaq.push(['_trackEvent', 'app', 'open_snapshot', null, contentLength]);
-
-  // TODO(benvanik): get from document? or in snapshot command?
-  this.setTitle_('snapshot');
-
-  // Create document with snapshot data.
-  var doc = new wtf.doc.Document(this.platform_);
-  this.openDocument(doc);
-
-  // This supports either 'content_buffers' with arrays/arraybuffers or
-  // 'content_urls' with a blob URLs with binary data.
-  if (data['content_buffers']) {
-    var datas = data['content_buffers'];
-    if (!datas.length) {
-      return;
-    }
-
-    // Convert data from Arrays to ensure we are typed all the way through.
-    for (var n = 0; n < datas.length; n++) {
-      if (goog.isArray(datas[n])) {
-        datas[n] = wtf.io.createByteArrayFromArray(datas[n]);
-      } else if (goog.isString(datas[n])) {
-        datas[n] = wtf.io.stringToNewByteArray(datas[n]);
-      }
-    }
-
-    // Append data after a bit - gives the UI time to setup.
-    wtf.timing.setImmediate(function() {
-      // Add all sources.
-      doc.addEventSources(datas, contentType);
-
-      // Zoom to fit.
-      // TODO(benvanik): remove setTimeout when zoomToFit is based on view
-      wtf.timing.setTimeout(50, function() {
-        this.documentView_.zoomToFit();
-      }, this);
-    }, this);
-  } else if (data['content_urls']) {
-    var blobUrls = data['content_urls'];
-
-    var deferreds = goog.array.map(blobUrls, function(blobUrl) {
-      var deferred = new goog.async.Deferred();
-      var xhr = new goog.net.XhrIo();
-      xhr.setResponseType(goog.net.XhrIo.ResponseType.ARRAY_BUFFER);
-      goog.events.listen(xhr, goog.net.EventType.COMPLETE, function() {
-        if (xhr.isSuccess()) {
-          var data = xhr.getResponse();
-          goog.asserts.assert(data);
-          deferred.callback(data);
-        } else {
-          deferred.errback('Failed to fetch');
-        }
-      });
-      xhr.send(blobUrl);
-      return deferred;
-    }, this);
-    goog.async.DeferredList.gatherResults(deferreds).addCallbacks(
-        function(datas) {
-          // Add all sources.
-          doc.addEventSources(datas, contentType);
-
-          // Zoom to fit.
-          // TODO(benvanik): remove setTimeout when zoomToFit is based on view
-          wtf.timing.setTimeout(50, function() {
-            this.documentView_.zoomToFit();
-          }, this);
-        },
-        function(args) {
-          wtf.ui.ErrorDialog.show(
-              'Unable to load snapshot',
-              'A blob from the source page could not be fetched.',
-              this.getDom());
-        }, this);
-  }
+  this.loader_.loadSnapshot(data);
 };
 
 
@@ -441,7 +333,7 @@ wtf.app.ui.MainDisplay.prototype.handleStreamCreatedCommand_ = function(data) {
   _gaq.push(['_trackEvent', 'app', 'open_stream']);
 
   // TODO(benvanik): get from document? or in stream command?
-  this.setTitle_('streaming');
+  this.setTitle('streaming');
 
   // TODO(benvanik): support multiple streams into the same trace/etc
   var doc = new wtf.doc.Document(this.platform_);
@@ -473,155 +365,11 @@ wtf.app.ui.MainDisplay.prototype.handleStreamAppendedCommand_ = function(data) {
 /**
  * Requests a load of a trace file.
  */
-wtf.app.ui.MainDisplay.prototype.requestTraceLoad = function() {
-  var dom = this.getDom();
-  var inputElement = dom.createElement(goog.dom.TagName.INPUT);
-  inputElement['type'] = 'file';
-  inputElement['multiple'] = true;
-  inputElement['accept'] = [
-    '.wtf-trace,application/x-extension-wtf-trace',
-    '.wtf-json,application/x-extension-wtf-json',
-    '.wtf-calls,application/x-extension-wtf-calls',
-    '.part,application/x-extension-part'
-  ].join(',');
-  inputElement.click();
-  goog.events.listenOnce(inputElement, goog.events.EventType.CHANGE,
-      function(e) {
-        _gaq.push(['_trackEvent', 'app', 'open_local_files']);
-        this.loadTraceFiles(inputElement.files);
-      }, false, this);
-};
-
-
-/**
- * Loads a list of trace files.
- * Multiple files are merged into a single trace session. The name will be
- * based on the first file found.
- * @param {!Array.<!File>} traceFiles Files to load.
- */
-wtf.app.ui.MainDisplay.prototype.loadTraceFiles = function(traceFiles) {
-  var entries = [];
-  for (var n = 0; n < traceFiles.length; n++) {
-    var file = traceFiles[n];
-    if (goog.string.endsWith(file.name, '.wtf-trace') ||
-        goog.string.endsWith(file.name, '.bin.part') ||
-        file.type == 'application/x-extension-wtf-trace') {
-      entries.push({
-        source: file,
-        filename: file.name,
-        mimeType: 'application/x-extension-wtf-trace'
-      });
-    } else if (goog.string.endsWith(file.name, '.wtf-json') ||
-        file.type == 'application/x-extension-wtf-json') {
-      entries.push({
-        source: file,
-        filename: file.name,
-        mimeType: 'application/x-extension-wtf-json'
-      });
-    } else if (goog.string.endsWith(file.name, '.wtf-calls') ||
-        file.type == 'application/x-extension-wtf-calls') {
-      entries.push({
-        source: file,
-        filename: file.name,
-        mimeType: 'application/x-extension-wtf-calls'
-      });
-    }
-  }
-  if (!entries.length) {
-    return;
-  }
-
-  // TODO(benvanik): move into wtf.db?
-  var deferreds = [];
-  for (var n = 0; n < entries.length; n++) {
-    var entry = entries[n];
-    switch (entry.mimeType) {
-      case 'application/x-extension-wtf-trace':
-      case 'application/x-extension-wtf-calls':
-        deferreds.push(goog.fs.FileReader.readAsArrayBuffer(entry.source));
-        break;
-      case 'application/x-extension-wtf-json':
-        deferreds.push(goog.fs.FileReader.readAsText(entry.source));
-        break;
-    }
-  }
-  this.openDeferredSources_(entries, deferreds);
-};
-
-
-/**
- * Load trace files by url.
- * @param {!Array.<!string>} urls Array of resources to load.
- */
-wtf.app.ui.MainDisplay.prototype.loadNetworkTraces = function(urls) {
-  var entries = [];
-  for (var n = 0; n < urls.length; n++) {
-    var url = urls[n];
-    if (goog.string.endsWith(url, '.wtf-trace') ||
-        goog.string.endsWith(url, '.bin.part')) {
-      entries.push({
-        source: url,
-        filename: url,
-        mimeType: 'application/x-extension-wtf-trace'
-      });
-    } else if (goog.string.endsWith(url, '.wtf-json')) {
-      entries.push({
-        source: url,
-        filename: url,
-        mimeType: 'application/x-extension-wtf-json'
-      });
-    } else if (goog.string.endsWith(url, '.wtf-calls')) {
-      entries.push({
-        source: url,
-        filename: url,
-        mimeType: 'application/x-extension-wtf-calls'
-      });
-    } else {
-      wtf.ui.ErrorDialog.show(
-          'Unsupported input URL',
-          'Only .wtf-trace, .wtf-json, and .wtf-calls inputs are supported.',
-          this.getDom());
-    }
-  }
-  if (!entries.length) {
-    return;
-  }
-
-  function loadUrl(url, responseType) {
-    var deferred = new goog.async.Deferred();
-
-    var xhr = new goog.net.XhrIo();
-    xhr.setResponseType(responseType);
-    goog.events.listen(xhr, goog.net.EventType.COMPLETE, function() {
-      if (xhr.isSuccess()) {
-        var data = xhr.getResponse();
-        goog.asserts.assert(data);
-        deferred.callback(data);
-      } else {
-        deferred.errback('Failed to load');
-      }
-    });
-    xhr.send(url);
-
-    return deferred;
-  }
-
-  var deferreds = [];
-  for (var n = 0; n < entries.length; n++) {
-    var entry = entries[n];
-    switch (entry.mimeType) {
-      case 'application/x-extension-wtf-trace':
-      case 'application/x-extension-wtf-calls':
-        deferreds.push(loadUrl(entry.source,
-            goog.net.XhrIo.ResponseType.ARRAY_BUFFER));
-        break;
-      case 'application/x-extension-wtf-json':
-        deferreds.push(loadUrl(entry.source,
-            goog.net.XhrIo.ResponseType.TEXT));
-        break;
-    }
-  }
-  this.openDeferredSources_(entries, deferreds);
+wtf.app.ui.MainDisplay.prototype.requestLocalTraceLoad = function() {
+  this.loader_.requestLocalOpenDialog(function selected() {
+    // Hide the splash dialog if it's up.
+    this.showSplashDialog_(false);
+  }, this);
 };
 
 
@@ -632,185 +380,13 @@ wtf.app.ui.MainDisplay.prototype.requestDriveTraceLoad = function() {
   // Hide the splash dialog if it's up.
   this.showSplashDialog_(false);
 
-  if (!wtf.io.drive.isSupported()) {
-    wtf.ui.ErrorDialog.show(
-        'Drive support not enabled',
-        'Drive is not supported in this build.',
-        this.getDom());
-    return;
-  }
-
-  goog.result.wait(wtf.io.drive.showFilePicker({
-    title: 'Select a trace file'
-  }), function(filesResult) {
-    var files = filesResult.getValue();
-    if (!files || !files.length) {
-      // Cancelled.
-      // If nothing is displayed, show the splash dialog.
-      if (!this.documentView_) {
-        this.showSplashDialog_(true);
-      }
-      return;
+  this.loader_.requestDriveOpenDialog(function cancelled() {
+    // Cancelled.
+    // If nothing is displayed, show the splash dialog.
+    if (!this.documentView_) {
+      this.showSplashDialog_(true);
     }
-
-    _gaq.push(['_trackEvent', 'app', 'open_drive_files']);
-
-    var deferreds = [];
-
-    var entries = [];
-    for (var n = 0; n < files.length; n++) {
-      var fileName = files[n][0];
-      var fileId = files[n][1];
-      var entry = {
-        source: fileId,
-        filename: fileName,
-        mimeType: 'application/x-extension-wtf-trace'
-      };
-      entries.push(entry);
-      var fileDeferred = new goog.async.Deferred();
-      deferreds.push(fileDeferred);
-      goog.result.wait(wtf.io.drive.downloadFile(fileId), function(result) {
-        var driveFile = result.getValue();
-        if (driveFile) {
-          entry.filename = driveFile.filename;
-          fileDeferred.callback(driveFile.contents);
-        } else {
-          fileDeferred.errback(result.getError());
-        }
-      }, this);
-    }
-
-    this.openDeferredSources_(entries, deferreds);
   }, this);
-};
-
-
-/**
- * Creates a document and adds sources for a set of deferred items. Each
- * deferred should provide a ArrayBuffer of binary source data or a string
- * of json data.
- * @param {!Array.<{
- *   source: *,
- *   filename: string,
- *   mimeType: string
- * }>} entries The list of deferred entries being opened. This must match up
- *     1:1 with the deferreds list.
- * @param {!Array.<!goog.async.Deferred>} deferreds a List of deferreds to wait
- *     on. Each should return an array buffer (for binary sources) or a string
- *     (for json sources).
- * @private
- */
-wtf.app.ui.MainDisplay.prototype.openDeferredSources_ = function(
-    entries, deferreds) {
-  var doc = new wtf.doc.Document(this.platform_);
-  this.openDocument(doc);
-
-  goog.async.DeferredList.gatherResults(deferreds).addCallbacks(
-      function(datas) {
-        var filenames = [];
-        var mimeTypes = [];
-        for (var n = 0; n < entries.length; n++) {
-          filenames.push(entries[n].filename);
-          mimeTypes.push(entries[n].mimeType);
-        }
-
-        // Add all data.
-        var contentLength = doc.addEventSources(datas, mimeTypes);
-        _gaq.push(['_trackEvent', 'app', 'open_files', null, contentLength]);
-
-        // Set title.
-        this.setTitleFromFilenames_(filenames);
-
-        // Zoom to fit.
-        // TODO(benvanik): remove setTimeout when zoomToFit is based on view
-        wtf.timing.setTimeout(50, function() {
-          this.documentView_.zoomToFit();
-        }, this);
-      },
-      function(arg) {
-        wtf.ui.ErrorDialog.show(
-            'Unable to load files',
-            'An input file could not be read.',
-            this.getDom());
-      }, this);
-};
-
-
-/**
- * Saves the current trace document, if any.
- * @private
- */
-wtf.app.ui.MainDisplay.prototype.saveTrace_ = function() {
-  if (!this.documentView_) {
-    return;
-  }
-
-  var doc = this.documentView_.getDocument();
-  var sources = doc.getDatabase().getSources();
-  if (!sources.length) {
-    return;
-  }
-  // Just pick the first source for naming.
-  var contextInfo = sources[0].getContextInfo();
-  var filename = contextInfo.getFilename();
-
-  // prefix-YYYY-MM-DDTHH-MM-SS
-  var dt = new Date();
-  var filenameSuffix = '-' +
-      dt.getFullYear() +
-      goog.string.padNumber(dt.getMonth() + 1, 2) +
-      goog.string.padNumber(dt.getDate(), 2) + 'T' +
-      goog.string.padNumber(dt.getHours(), 2) +
-      goog.string.padNumber(dt.getMinutes(), 2) +
-      goog.string.padNumber(dt.getSeconds(), 2);
-  filename += filenameSuffix;
-
-  var storage = doc.getStorage();
-  var dataStreams = storage.snapshotDataStreamBuffers();
-  var contentLength = 0;
-  for (var n = 0; n < dataStreams.length; n++) {
-    var dataStream = dataStreams[n];
-    var streamFilename = filename;
-    if (dataStreams.length > 1) {
-      streamFilename += '-' + n;
-    }
-    switch (dataStream.type) {
-      case 'application/x-extension-wtf-trace':
-        streamFilename += wtf.io.FILE_EXTENSION;
-        break;
-    }
-    var platform = wtf.pal.getPlatform();
-    platform.writeBinaryFile(streamFilename, dataStream.data, dataStream.type);
-    contentLength += dataStream.data.length;
-  }
-  _gaq.push(['_trackEvent', 'app', 'save_trace', null, contentLength]);
-};
-
-
-/**
- * Saves the current trace document to Drive, if any.
- * @private
- */
-wtf.app.ui.MainDisplay.prototype.saveDriveTrace_ = function() {
-  if (!this.documentView_) {
-    return;
-  }
-
-  if (!wtf.io.drive.isSupported()) {
-    wtf.ui.ErrorDialog.show(
-        'Drive support not enabled',
-        'Drive is not supported in this build.',
-        this.getDom());
-    return;
-  }
-
-  _gaq.push(['_trackEvent', 'app', 'save_drive_trace']);
-
-  // TODO(benvanik): save to drive.
-  wtf.ui.ErrorDialog.show(
-      'Drive saving not implemented',
-      'Sorry, this isn\'t implemented yet!',
-      this.getDom());
 };
 
 

--- a/src/wtf/app/ui/nav/navbar.js
+++ b/src/wtf/app/ui/nav/navbar.js
@@ -182,14 +182,9 @@ wtf.app.ui.nav.Navbar = function(documentView, parentElement) {
   // TODO(benvanik): remove view widget when the view is removed.
 
   // Reset all painters on database change.
-  db.addListener(wtf.events.EventType.INVALIDATED, function() {
-    var firstEventTime = db.getFirstEventTime();
-    var lastEventTime = db.getLastEventTime();
-    for (var n = 0; n < this.timePainters_.length; n++) {
-      this.timePainters_[n].setTimeRange(firstEventTime, lastEventTime);
-    }
-    this.requestRepaint();
-  }, this);
+  db.addListener(
+      wtf.events.EventType.INVALIDATED, this.databaseInvalidated_, this);
+  this.databaseInvalidated_();
 
   this.requestRepaint();
 };
@@ -238,6 +233,21 @@ wtf.app.ui.nav.Navbar.MAX_GRANULARITY_ =
 wtf.app.ui.nav.Navbar.prototype.createDom = function(dom) {
   return /** @type {!Element} */ (goog.soy.renderAsFragment(
       wtf.app.ui.nav.navbar.control, undefined, undefined, dom));
+};
+
+
+/**
+ * Handles database invalidations.
+ * @private
+ */
+wtf.app.ui.nav.Navbar.prototype.databaseInvalidated_ = function() {
+  var db = this.db_;
+  var firstEventTime = db.getFirstEventTime();
+  var lastEventTime = db.getLastEventTime();
+  for (var n = 0; n < this.timePainters_.length; n++) {
+    this.timePainters_[n].setTimeRange(firstEventTime, lastEventTime);
+  }
+  this.requestRepaint();
 };
 
 

--- a/src/wtf/app/ui/selection.js
+++ b/src/wtf/app/ui/selection.js
@@ -71,6 +71,7 @@ wtf.app.ui.Selection = function(db) {
 
   db.addListener(
       wtf.events.EventType.INVALIDATED, this.invalidate_, this);
+  this.invalidate_();
 };
 goog.inherits(wtf.app.ui.Selection, wtf.events.EventEmitter);
 

--- a/src/wtf/app/ui/splashdialog.js
+++ b/src/wtf/app/ui/splashdialog.js
@@ -18,6 +18,7 @@ goog.require('goog.soy');
 goog.require('wtf.app.ui.splashdialog');
 goog.require('wtf.events');
 goog.require('wtf.events.Keyboard');
+goog.require('wtf.events.KeyboardScope');
 goog.require('wtf.io.drive');
 goog.require('wtf.ui.Dialog');
 goog.require('wtf.version');
@@ -38,13 +39,20 @@ wtf.app.ui.SplashDialog = function(parentElement, opt_dom) {
     clickToClose: false
   }, parentElement, opt_dom);
 
+  var dom = this.getDom();
   var commandManager = wtf.events.getCommandManager();
+
+  // Setup keyboard shortcuts.
+  var keyboard = wtf.events.getWindowKeyboard(dom);
+  var keyboardScope = new wtf.events.KeyboardScope(keyboard);
+  this.registerDisposable(keyboardScope);
+  keyboardScope.addCommandShortcut('command+o', 'open_local_trace');
 
   var eh = this.getHandler();
   eh.listen(this.getChildElement(goog.getCssName('openButton')),
       goog.events.EventType.CLICK, function(e) {
         e.preventDefault();
-        commandManager.execute('open_trace', this, null);
+        commandManager.execute('open_local_trace', this, null);
       }, false);
   if (wtf.io.drive.isSupported()) {
     eh.listen(this.getChildElement(goog.getCssName('openDriveButton')),

--- a/src/wtf/app/ui/toolbar.js
+++ b/src/wtf/app/ui/toolbar.js
@@ -22,6 +22,7 @@ goog.require('wtf.data.ScriptContextInfo');
 goog.require('wtf.events');
 goog.require('wtf.events.EventType');
 goog.require('wtf.events.Keyboard');
+goog.require('wtf.events.KeyboardScope');
 goog.require('wtf.ui.Control');
 
 
@@ -94,6 +95,14 @@ wtf.app.ui.Toolbar = function(documentView, parentElement) {
   this.toggleButton(goog.getCssName('buttonSave'), true);
   this.toggleButton(goog.getCssName('buttonSettings'), true);
   this.toggleButton(goog.getCssName('buttonHelp'), true);
+
+  // Setup keyboard shortcuts.
+  var keyboard = wtf.events.getWindowKeyboard(dom);
+  var keyboardScope = new wtf.events.KeyboardScope(keyboard);
+  this.registerDisposable(keyboardScope);
+  keyboardScope.addCommandShortcut('command+o', 'open_local_trace');
+  keyboardScope.addCommandShortcut('command+s', 'save_local_trace');
+  keyboardScope.addCommandShortcut('shift+/', 'toggle_help');
 
   var db = documentView.getDatabase();
   db.addListener(
@@ -203,7 +212,7 @@ wtf.app.ui.Toolbar.prototype.viewHealthClicked_ = function(e) {
 wtf.app.ui.Toolbar.prototype.openClicked_ = function(e) {
   e.preventDefault();
   var commandManager = wtf.events.getCommandManager();
-  commandManager.execute('open_trace', this, null);
+  commandManager.execute('open_local_trace', this, null);
 };
 
 
@@ -215,7 +224,7 @@ wtf.app.ui.Toolbar.prototype.openClicked_ = function(e) {
 wtf.app.ui.Toolbar.prototype.saveClicked_ = function(e) {
   e.preventDefault();
   var commandManager = wtf.events.getCommandManager();
-  commandManager.execute('save_trace', this, null);
+  commandManager.execute('save_local_trace', this, null);
 };
 
 

--- a/src/wtf/app/ui/tracks/trackinfobar.js
+++ b/src/wtf/app/ui/tracks/trackinfobar.js
@@ -147,6 +147,7 @@ wtf.app.ui.tracks.TrackInfoBar = function(tracksPanel, parentElement) {
   db.addListener(wtf.events.EventType.INVALIDATED, function() {
     this.updateInfo_();
   }, this);
+  this.updateInfo_();
 };
 goog.inherits(wtf.app.ui.tracks.TrackInfoBar, wtf.ui.ResizableControl);
 

--- a/src/wtf/app/ui/tracks/trackspanel.js
+++ b/src/wtf/app/ui/tracks/trackspanel.js
@@ -389,6 +389,9 @@ wtf.app.ui.tracks.TracksPanel.prototype.viewportChanged_ = function() {
 
   // Update from viewport.
   var width = this.viewport_.getScreenWidth();
+  if (width <= 1) {
+    return;
+  }
   var timeLeft = this.viewport_.screenToScene(0, 0).x;
   var timeRight = this.viewport_.screenToScene(width, 0).x;
   timeLeft += firstEventTime;

--- a/src/wtf/app/ui/ui.less
+++ b/src/wtf/app/ui/ui.less
@@ -20,6 +20,7 @@
 @import "wtf/app/ui/documentview.less";
 @import "wtf/app/ui/healthdialog.less";
 @import "wtf/app/ui/helpdialog.less";
+@import "wtf/app/ui/loadingdialog.less";
 @import "wtf/app/ui/maindisplay.less";
 @import "wtf/app/ui/splashdialog.less";
 @import "wtf/app/ui/statusbar.less";

--- a/src/wtf/data/contextinfo.js
+++ b/src/wtf/data/contextinfo.js
@@ -91,6 +91,13 @@ wtf.data.ContextInfo.prototype.write = function(buffer) {
 
 
 /**
+ * Gets a human-readable version of the context info.
+ * @return {string} String version.
+ */
+wtf.data.ContextInfo.prototype.toString = goog.abstractMethod;
+
+
+/**
  * Parses context information from the given buffer.
  * The appropriate subclass type will be returned.
  * @param {!wtf.io.Buffer} buffer Source buffer.
@@ -414,4 +421,12 @@ wtf.data.ScriptContextInfo.prototype.serialize = function() {
       'device': this.userAgent.device
     }
   };
+};
+
+
+/**
+ * @override
+ */
+wtf.data.ScriptContextInfo.prototype.toString = function() {
+  return this.title || this.uri;
 };

--- a/src/wtf/db/database.js
+++ b/src/wtf/db/database.js
@@ -232,8 +232,9 @@ wtf.db.Database.prototype.addStreamingSource = function(stream) {
 /**
  * Adds a binary data source as an immediately-available stream.
  * @param {!wtf.io.ByteArray} data Input data.
+ * @param {wtf.db.DataSourceInfo=} opt_sourceInfo Source information.
  */
-wtf.db.Database.prototype.addBinarySource = function(data) {
+wtf.db.Database.prototype.addBinarySource = function(data, opt_sourceInfo) {
   // Create a stream wrapper for the input data.
   var stream = new wtf.io.MemoryReadStream();
   stream.addData(data);
@@ -250,8 +251,9 @@ wtf.db.Database.prototype.addBinarySource = function(data) {
 /**
  * Adds a JSON data source as an immediately-available stream.
  * @param {string|!Array|!Object} data Input data.
+ * @param {wtf.db.DataSourceInfo=} opt_sourceInfo Source information.
  */
-wtf.db.Database.prototype.addJsonSource = function(data) {
+wtf.db.Database.prototype.addJsonSource = function(data, opt_sourceInfo) {
   // TODO(benvanik): send to storage so that saves work
 
   this.addDataSource(new wtf.db.sources.JsonDataSource(this, data));
@@ -261,8 +263,9 @@ wtf.db.Database.prototype.addJsonSource = function(data) {
 /**
  * Adds a binary instrumented call source as an immediately-available stream.
  * @param {!wtf.io.ByteArray} data Input data.
+ * @param {wtf.db.DataSourceInfo=} opt_sourceInfo Source information.
  */
-wtf.db.Database.prototype.addCallsSource = function(data) {
+wtf.db.Database.prototype.addCallsSource = function(data, opt_sourceInfo) {
   // TODO(benvanik): support mimetype storage?
   // Send to storage, if needed.
   // if (this.storage_) {

--- a/src/wtf/db/datasource.js
+++ b/src/wtf/db/datasource.js
@@ -12,10 +12,48 @@
  */
 
 goog.provide('wtf.db.DataSource');
+goog.provide('wtf.db.DataSourceInfo');
 
 goog.require('goog.Disposable');
 goog.require('goog.asserts');
 goog.require('wtf.data.formats.FileFlags');
+
+
+
+/**
+ * Source information about a data source.
+ * @param {string} filename Filename or URL.
+ * @param {string} contentType MIME type.
+ * @constructor
+ */
+wtf.db.DataSourceInfo = function(filename, contentType) {
+  /**
+   * @type {string}
+   */
+  this.filename = filename;
+
+  /**
+   * @type {string}
+   */
+  this.contentType = contentType;
+};
+
+
+/**
+ * Gets a value indicating whether the source data is binary (vs. text).
+ * @return {boolean} True if binary, false if text.
+ */
+wtf.db.DataSourceInfo.prototype.isBinary = function() {
+  // Guess the response type from the content type.
+  switch (this.contentType) {
+    default:
+    case 'application/x-extension-wtf-trace':
+    case 'application/x-extension-wtf-calls':
+      return true;
+    case 'application/x-extension-wtf-json':
+      return false;
+  }
+};
 
 
 

--- a/src/wtf/doc/document.js
+++ b/src/wtf/doc/document.js
@@ -25,7 +25,6 @@ goog.require('wtf.doc.View');
 goog.require('wtf.events.EventEmitter');
 goog.require('wtf.events.SimpleEventfulList');
 goog.require('wtf.events.SimpleEventfulMap');
-goog.require('wtf.io');
 goog.require('wtf.io.MemoryReadStream');
 
 
@@ -303,58 +302,6 @@ wtf.doc.Document.prototype.endEventStream = function(streamId) {
   if (goog.object.isEmpty(this.readStreams_)) {
     this.setStatus(wtf.doc.DocumentStatus.STATIC);
   }
-};
-
-
-/**
- * Adds an event data source to the database.
- * The given data can be a binary array or some form of JSON.
- * @param {!wtf.io.ByteArray|string|!Object|!ArrayBuffer} data Source data.
- * @param {string} mimeType Mime type.
- * @return {number} Estimated size, in bytes, of the data source.
- */
-wtf.doc.Document.prototype.addEventSource = function(data, mimeType) {
-  // Wrap array buffers.
-  if (data instanceof ArrayBuffer) {
-    data = new Uint8Array(data);
-  }
-
-  switch (mimeType) {
-    case 'application/x-extension-wtf-trace':
-      goog.asserts.assert(wtf.io.isByteArray(data));
-      this.db_.addBinarySource(/** @type {!wtf.io.ByteArray} */ (data));
-      return data.length;
-      break;
-    case 'application/x-extension-wtf-json':
-      this.db_.addJsonSource(data);
-      return goog.isString(data) ? data.length : 0;
-    case 'application/x-extension-wtf-calls':
-      goog.asserts.assert(wtf.io.isByteArray(data));
-      this.db_.addCallsSource(/** @type {!wtf.io.ByteArray} */ (data));
-      return data.length;
-    default:
-      goog.asserts.fail('Unsupported mime type: ' + mimeType);
-      return 0;
-  }
-};
-
-
-/**
- * Adds a list of event sources to the database.
- * The given data can be binary arrays or some form of JSON.
- * @param {!Array.<!wtf.io.ByteArray|string|!Object|!ArrayBuffer>} datas Source
- *     data list.
- * @param {string|!Array.<string>} mimeTypes A mime type to use for all data
- *     or a 1:1 mapping to the datas list.
- * @return {number} Estimated size, in bytes, of all the data sources.
- */
-wtf.doc.Document.prototype.addEventSources = function(datas, mimeTypes) {
-  var contentLength = 0;
-  for (var n = 0; n < datas.length; n++) {
-    var mimeType = goog.isArray(mimeTypes) ? mimeTypes[n] : mimeTypes;
-    contentLength += this.addEventSource(datas[n], mimeType);
-  }
-  return contentLength;
 };
 
 

--- a/src/wtf/io/drive.js
+++ b/src/wtf/io/drive.js
@@ -265,7 +265,7 @@ wtf.io.drive.showFilePicker = function(options) {
  *   filename: string,
  *   fileExtension: string,
  *   mimeType: string,
- *   contents: (ArrayBuffer|string)
+ *   xhr: !XMLHttpRequest
  * }}
  */
 wtf.io.drive.DriveFile;
@@ -281,7 +281,10 @@ wtf.io.drive.downloadFileLoadResult_ = null;
 
 
 /**
- * Downloads a file from Drive.
+ * Begins downloading a file from Drive.
+ * The async result from this is an XHR that is about to start downloading. Just
+ * call {@code send()} on it to kick off the process. This allows you to listen
+ * for any progress events you require.
  * @param {string} fileId Drive file ID.
  * @return {!goog.result.Result} Async result. The value will be a
  *     {@see wtf.io.drive.DriveFile} object.
@@ -359,19 +362,15 @@ wtf.io.drive.downloadFile = function(fileId) {
 
     xhr.open('GET', downloadUrl, true);
     xhr.setRequestHeader('Authorization', 'Bearer ' + accessToken);
-    xhr.onload = function() {
-      if (xhr.status != 200) {
-        result.setError();
-        return;
-      }
-
-      driveFile.contents = xhr.response;
-      result.setValue(driveFile);
-    };
     xhr.onerror = function() {
       result.setError();
     };
-    xhr.send(null);
+
+    // We don't send here, as we let the caller do it.
+    // xhr.send(null);
+    driveFile.xhr = xhr;
+
+    result.setValue(driveFile);
   };
 
   return result;

--- a/src/wtf/ui/control.js
+++ b/src/wtf/ui/control.js
@@ -160,11 +160,13 @@ wtf.ui.Control.prototype.getRootElement = function() {
 /**
  * Gets the first child element with the given class name.
  * @param {string} className CSS class name.
+ * @param {Element=} opt_root Root element.
  * @return {!Element} Element.
  * @protected
  */
-wtf.ui.Control.prototype.getChildElement = function(className) {
-  var value = this.dom_.getElementByClass(className, this.rootElement_);
+wtf.ui.Control.prototype.getChildElement = function(className, opt_root) {
+  var value = this.dom_.getElementByClass(
+      className, opt_root || this.rootElement_);
   goog.asserts.assert(value);
   return /** @type {!Element} */ (value);
 };

--- a/src/wtf/ui/settingsdialog.js
+++ b/src/wtf/ui/settingsdialog.js
@@ -90,7 +90,9 @@ wtf.ui.SettingsDialog = function(options, title, parentElement, opt_dom) {
       }, false, this);
   eh.listen(
       this.getChildElement(goog.getCssName('buttonCancel')),
-      goog.events.EventType.CLICK, this.close, false, this);
+      goog.events.EventType.CLICK, function() {
+        this.close();
+      }, false, this);
 };
 goog.inherits(wtf.ui.SettingsDialog, wtf.ui.Dialog);
 

--- a/src/wtf/ui/styles/css3.less
+++ b/src/wtf/ui/styles/css3.less
@@ -82,3 +82,14 @@
   -o-transform: @value;
   transform: @value;
 }
+
+.animation(@name, @duration, @timingFunction: linear, @count: infinite) {
+  -webkit-animation-name: @name;
+  -webkit-animation-duration: @duration;
+  -webkit-animation-timing-function: @timingFunction;
+  -webkit-animation-iteration-count: @count;
+  animation-name: @name;
+  animation-duration: @duration;
+  animation-timing-function: @timingFunction;
+  animation-iteration-count: @count;
+}

--- a/src/wtf/ui/styles/kennedy.less
+++ b/src/wtf/ui/styles/kennedy.less
@@ -649,4 +649,44 @@
     background-repeat: no-repeat;
     background-position-x: 5px;
   }
+
+  .kProgressBar {
+    width: 320px;
+    border: 1px solid #999;
+    padding: 1px;
+    .track {
+      width: 0px;
+      height: 8px;
+
+      .boxShadow(0px, 1px, 1px, rgba(0,0,0,0.1));
+
+      background-repeat: repeat-x;
+      background-position: 0 0;
+      background-size: 20px 10px;
+
+      background-color: rgba(0,0,0,0.12);
+      background-image: -webkit-linear-gradient(315deg, transparent, transparent 33%, rgba(0,0,0,0.12) 33%, rgba(0,0,0,0.12) 66%, transparent 66%, transparent);
+      background-image: -moz-linear-gradient(315deg, transparent, transparent 33%, rgba(0,0,0,0.12) 33%, rgba(0,0,0,0.12) 66%, transparent 66%, transparent);
+      background-image: -ms-linear-gradient(315deg, transparent, transparent 33%, rgba(0,0,0,0.12) 33%, rgba(0,0,0,0.12) 66%, transparent 66%, transparent);
+      background-image: -o-linear-gradient(315deg, transparent, transparent 33%, rgba(0,0,0,0.12) 33%, rgba(0,0,0,0.12) 66%, transparent 66%, transparent);
+      background-image: linear-gradient(315deg, transparent, transparent 33%, rgba(0,0,0,0.12) 33%, rgba(0,0,0,0.12) 66%, transparent 66%, transparent);
+
+      .animation(kProgressBarAnimation, 0.8s, linear, infinite);
+    }
+    .blue {
+      background-color: #6188f5;
+    }
+  }
+  .kProgressText {
+    color: #999;
+  }
+}
+
+@-webkit-keyframes kProgressBarAnimation {
+  0% { background-position:0 0; }
+  100% { background-position:-20px 0; }
+}
+@keyframes kProgressBarAnimation {
+  0% { background-position:0 0; }
+  100% { background-position:-20px 0; }
 }

--- a/wtfrc
+++ b/wtfrc
@@ -5,3 +5,4 @@
 alias anvil='./third_party/anvil-build/anvil-local.sh'
 
 alias deployext='anvil deploy -o build-bin/ injector/wtf-injector-chrome:deploy'
+alias deployzip='anvil deploy -o build-bin/ :injector'


### PR DESCRIPTION
This is a large cleanup of the loading code to be much easier to maintain
and fixes a lot of bugs. It now supports progress events, deduplicates a
lot of the nasty logic, and is setup to handle new types better.

Primarily fixes #271, works on #266 (filenames are now carried, though not
used on save).

A lot of things were fixed, namely:
- Doesn't show the splash screen on a snapshot from a tab.
- Fixes error messages for several trace load failure types.
- Fixes a startup issue with traces not snapping to the right viewport.
- Moves the saving code into DocumentView, where it belongs.
- Sets the app tab title to the filename on snapshots.
- Fixes # some dialog issues (like remaining up on the screen).
- Revokes blob: URLs after loading, fixing a leak in the Browser.
- Closes Files after loading, freeing their memory much faster.
- Better tracks mime types (for the future, when DataStore is better).
