### PR TITLE
Hides the navbar for wtf-calls traces.

### DIFF
--- a/src/wtf/app/ui/documentview.js
+++ b/src/wtf/app/ui/documentview.js
@@ -431,7 +431,7 @@ wtf.app.ui.DocumentView.prototype.layoutInternal = function() {
   goog.style.setHeight(this.tabbar_.getRootElement(), tabbarHeight);
 
   // Reset limits and keep the splitter above the fold when resizing the window.
-  var navbarMinHeight = wtf.app.ui.nav.Navbar.MIN_HEIGHT;
+  var navbarMinHeight = this.navbar_.getMinimumSize();
   var navbarMaxHeight = wtf.app.ui.nav.Navbar.MAX_HEIGHT;
   this.navbar_.setSplitterLimits(
       navbarMinHeight, Math.min(navbarMaxHeight, currentSize.height));

--- a/src/wtf/app/ui/nav/navbar.js
+++ b/src/wtf/app/ui/nav/navbar.js
@@ -26,6 +26,7 @@ goog.require('wtf.app.ui.nav.TimelinePainter');
 goog.require('wtf.app.ui.nav.navbar');
 goog.require('wtf.db.Database');
 goog.require('wtf.db.Granularity');
+goog.require('wtf.db.PresentationHint');
 goog.require('wtf.events.EventType');
 goog.require('wtf.events.ListEventType');
 goog.require('wtf.math');
@@ -70,6 +71,27 @@ wtf.app.ui.nav.Navbar = function(documentView, parentElement) {
    * @private
    */
   this.db_ = db;
+
+  /**
+   * Whether the navbar is enabled.
+   * Some data sources disable us because they have nothing interesting to show.
+   * @type {boolean}
+   * @private
+   */
+  this.enabled_ = false;
+  var dataSources = db.getSources();
+  for (var n = 0; n < dataSources.length; n++) {
+    var presentationHints = dataSources[n].getPresentationHints();
+    // If any datasource is not bare, show the UI.
+    if (!(presentationHints & wtf.db.PresentationHint.BARE)) {
+      this.enabled_ = true;
+    }
+  }
+  if (!this.enabled_) {
+    this.setSplitterLimits(0, undefined);
+    this.setSplitterSize(0);
+    return;
+  }
 
   /**
    * Navbar canvas.

--- a/src/wtf/db/datasource.js
+++ b/src/wtf/db/datasource.js
@@ -13,6 +13,7 @@
 
 goog.provide('wtf.db.DataSource');
 goog.provide('wtf.db.DataSourceInfo');
+goog.provide('wtf.db.PresentationHint');
 
 goog.require('goog.Disposable');
 goog.require('goog.asserts');
@@ -53,6 +54,27 @@ wtf.db.DataSourceInfo.prototype.isBinary = function() {
     case 'application/x-extension-wtf-json':
       return false;
   }
+};
+
+
+/**
+ * Bitmask values indicating hints to the UI displaying the data.
+ * The UI is free to ignore any of these.
+ * @enum {number}
+ */
+wtf.db.PresentationHint = {
+  /**
+   * The data in the source should disable most (if not all) of the higher
+   * level navigation structures such as frames and features like heatmaps as
+   * the data doesn't contain the events needed to build such tables.
+   */
+  BARE: 1 << 0,
+
+  /**
+   * The data source contains no rendering data, such as frames.
+   * This can be used to hide UI elements related to frames, timing, etc.
+   */
+  NO_RENDER_DATA: 1 << 1
 };
 
 
@@ -103,6 +125,14 @@ wtf.db.DataSource = function(db) {
    * @private
    */
   this.flags_ = 0;
+
+  /**
+   * Hints to the UI that can help it decide what kind of view to show.
+   * These may be ignored. A bitmask of values of
+   * {@see wtf.db.PresentationHint}.
+   * @type {number}
+   */
+  this.presentationHints_ = 0;
 
   /**
    * File metadata.
@@ -178,6 +208,16 @@ wtf.db.DataSource.prototype.hasHighResolutionTimes = function() {
 
 
 /**
+ * Gets the bitmask of {@see wtf.db.PresentationHint} values that can be used to
+ * help a UI decide what to draw.
+ * @return {number} Bitmask.
+ */
+wtf.db.DataSource.prototype.getPresentationHints = function() {
+  return this.presentationHints_;
+};
+
+
+/**
  * Gets embedded file metadata.
  * @return {!Object} Metadata.
  */
@@ -218,18 +258,20 @@ wtf.db.DataSource.prototype.start = goog.nullFunction;
  * the trace source.
  * @param {!wtf.data.ContextInfo} contextInfo Context information.
  * @param {number} flags A bitmask of {@see wtf.data.formats.FileFlags} values.
+ * @param {number} presentationHints Bitmask of presentation hints.
  * @param {!Object} metadata File metadata.
  * @param {number} timebase Time base for all time values read.
  * @param {number} timeDelay Estimated time delay.
  * @protected
  */
 wtf.db.DataSource.prototype.initialize = function(
-    contextInfo, flags, metadata, timebase, timeDelay) {
+    contextInfo, flags, presentationHints, metadata, timebase, timeDelay) {
   goog.asserts.assert(!this.isInitialized_);
   this.isInitialized_ = true;
 
   this.contextInfo_ = contextInfo;
   this.flags_ = flags;
+  this.presentationHints_ = presentationHints;
   this.metadata_ = metadata;
   this.timebase_ = timebase;
   this.timeDelay_ = timeDelay;
@@ -245,6 +287,9 @@ goog.exportProperty(
 goog.exportProperty(
     wtf.db.DataSource.prototype, 'hasHighResolutionTimes',
     wtf.db.DataSource.prototype.hasHighResolutionTimes);
+goog.exportProperty(
+    wtf.db.DataSource.prototype, 'getPresentationHints',
+    wtf.db.DataSource.prototype.getPresentationHints);
 goog.exportProperty(
     wtf.db.DataSource.prototype, 'getMetadata',
     wtf.db.DataSource.prototype.getMetadata);

--- a/src/wtf/db/sources/binarydatasource.js
+++ b/src/wtf/db/sources/binarydatasource.js
@@ -259,7 +259,7 @@ wtf.db.sources.BinaryDataSource.prototype.readTraceHeader_ =
 
   // Initialize the trace source.
   // Only call when all other parsing has been successful.
-  this.initialize(contextInfo, flags, metadata, timebase, timeDelay);
+  this.initialize(contextInfo, flags, 0, metadata, timebase, timeDelay);
 
   // Add builtin events for this version.
   switch (formatVersion) {

--- a/src/wtf/db/sources/callsdatasource.js
+++ b/src/wtf/db/sources/callsdatasource.js
@@ -20,6 +20,7 @@ goog.require('wtf.data.formats.BinaryCalls');
 goog.require('wtf.data.formats.FileFlags');
 goog.require('wtf.db.DataSource');
 goog.require('wtf.db.EventType');
+goog.require('wtf.db.PresentationHint');
 goog.require('wtf.io');
 goog.require('wtf.util');
 
@@ -119,7 +120,13 @@ wtf.db.sources.CallsDataSource.prototype.start = function() {
     metadata = {};
   }
 
-  this.initialize(contextInfo, flags, metadata, timebase, timeDelay);
+  // Assume we are always special. In the future the file can specify this.
+  var presentationHints = 0;
+  presentationHints |= wtf.db.PresentationHint.NO_RENDER_DATA;
+  presentationHints |= wtf.db.PresentationHint.BARE;
+
+  this.initialize(
+      contextInfo, flags, presentationHints, metadata, timebase, timeDelay);
 
   // Setup some builtin event types.
   var leaveEventType = eventTypeTable.defineType(

--- a/src/wtf/db/sources/jsondatasource.js
+++ b/src/wtf/db/sources/jsondatasource.js
@@ -321,7 +321,7 @@ wtf.db.sources.JsonDataSource.prototype.parseHeader_ = function(entry) {
   var contextInfo = new wtf.data.ScriptContextInfo();
 
   var timeDelay = db.computeTimeDelay(timebase);
-  this.initialize(contextInfo, flags, metadata, timebase, timeDelay);
+  this.initialize(contextInfo, flags, 0, metadata, timebase, timeDelay);
 
   return true;
 };

--- a/src/wtf/ui/resizablecontrol.js
+++ b/src/wtf/ui/resizablecontrol.js
@@ -58,7 +58,7 @@ wtf.ui.ResizableControl = function(orientation, splitterClassName,
    * @type {number}
    * @private
    */
-  this.currentSize_ = 0;
+  this.currentSize_ = -1;
   wtf.timing.setImmediate(function() {
     var currentSize = goog.style.getSize(this.getRootElement());
     switch (orientation) {
@@ -231,6 +231,24 @@ wtf.ui.ResizableControl.prototype.setSizeFrom = function(value) {
       }
       break;
   }
+};
+
+
+/**
+ * Gets the minimum size of the control.
+ * @return {number|undefined} Minimum size or undefined if none specified.
+ */
+wtf.ui.ResizableControl.prototype.getMinimumSize = function() {
+  return this.minimumSize_;
+};
+
+
+/**
+ * Gets the maximum size of the control.
+ * @return {number|undefined} Maximum size or undefined if none specified.
+ */
+wtf.ui.ResizableControl.prototype.getMaximumSize = function() {
+  return this.maximumSize_;
 };
 
 


### PR DESCRIPTION
This prevents it from trying to process data/create indices/etc and
other future stats work when it's not useful. It also saves a bunch of
vertical space.
