### PR TITLE
Speeding up zone painting.

### DIFF
--- a/src/wtf/data/eventflag.js
+++ b/src/wtf/data/eventflag.js
@@ -17,6 +17,9 @@ goog.provide('wtf.data.EventFlag');
 /**
  * Event behavior flag bitmask.
  * Values can be ORed together to indicate different behaviors an event has.
+ *
+ * NOTE: the database currently stores this as a 16bit value. Don't use more!
+ *
  * @enum {number}
  */
 wtf.data.EventFlag = {

--- a/src/wtf/db/eventlist.js
+++ b/src/wtf/db/eventlist.js
@@ -310,7 +310,8 @@ wtf.db.EventList.prototype.insert = function(eventType, time, opt_argData) {
   var eventData = this.eventData;
   var o = this.count * wtf.db.EventStruct.STRUCT_SIZE;
   eventData[o + wtf.db.EventStruct.ID] = this.count;
-  eventData[o + wtf.db.EventStruct.TYPE] = eventType.id;
+  eventData[o + wtf.db.EventStruct.TYPE] =
+      eventType.id | (eventType.flags << 16);
   eventData[o + wtf.db.EventStruct.PARENT] = -1;
   eventData[o + wtf.db.EventStruct.TIME] = time;
 
@@ -475,7 +476,7 @@ wtf.db.EventList.prototype.rescopeEvents_ = function() {
     }
     eventData[o + wtf.db.EventStruct.NEXT_SIBLING] = nextEventId;
 
-    var typeId = eventData[o + wtf.db.EventStruct.TYPE];
+    var typeId = eventData[o + wtf.db.EventStruct.TYPE] & 0xFFFF;
     var deleteArgs = false;
     if (typeId == scopeEnterId) {
       // Generic scope enter.
@@ -489,7 +490,8 @@ wtf.db.EventList.prototype.rescopeEvents_ = function() {
             wtf.db.EventType.createScope(name));
       }
       typeId = newEventType.id;
-      eventData[o + wtf.db.EventStruct.TYPE] = newEventType.id;
+      eventData[o + wtf.db.EventStruct.TYPE] =
+          newEventType.id | (newEventType.flags << 16);
       stack[++stackTop] = eventData[o + wtf.db.EventStruct.ID];
       typeStack[stackTop] = newEventType;
       stackMax = Math.max(stackMax, stackTop);
@@ -545,7 +547,8 @@ wtf.db.EventList.prototype.rescopeEvents_ = function() {
             wtf.db.EventType.createInstance(name));
       }
       typeId = newEventType.id;
-      eventData[o + wtf.db.EventStruct.TYPE] = newEventType.id;
+      eventData[o + wtf.db.EventStruct.TYPE] =
+          newEventType.id | (newEventType.flags << 16);
       deleteArgs = true;
       statistics.genericTimeStamp++;
     } else {
@@ -671,7 +674,7 @@ wtf.db.EventList.prototype.rebuildAncillaryLists_ = function(lists) {
   var eventData = this.eventData;
   var it = new wtf.db.EventIterator(this, 0, this.count - 1, 0);
   for (var n = 0, o = 0; n < this.count; n++) {
-    var typeId = eventData[o + wtf.db.EventStruct.TYPE];
+    var typeId = eventData[o + wtf.db.EventStruct.TYPE] & 0xFFFF;
     var handlers = typeMap[typeId];
     if (handlers) {
       for (var m = 0; m < handlers.length; m++) {

--- a/src/wtf/db/eventstruct.js
+++ b/src/wtf/db/eventstruct.js
@@ -25,8 +25,13 @@ wtf.db.EventStruct = {
   ID: 0,
 
   /**
-   * Event type ID.
+   * Event type ID and type flags.
    * Retrieve the {@see wtf.db.EventType} via the {@see wtf.db.EventTypeTable}.
+   * The flags are in the upper 16bits, the ID is in the lower.
+   * <code>
+   * var typeId = data[TYPE] & 0xFFFF;
+   * var flags = data[TYPE] >>> 16;
+   * </code>
    */
   TYPE: 1,
 

--- a/src/wtf/io/buffer.js
+++ b/src/wtf/io/buffer.js
@@ -174,7 +174,7 @@ wtf.io.Buffer.prototype.writeInt16 = function(value) {
   this.ensureCapacity_(2);
   var data = this.data;
   var offset = this.offset;
-  data[offset++] = (value >> 8) & 0xFF;
+  data[offset++] = (value >>> 8) & 0xFF;
   data[offset++] = value & 0xFF;
   this.offset = offset;
 };
@@ -206,9 +206,9 @@ wtf.io.Buffer.prototype.writeInt32 = function(value) {
   this.ensureCapacity_(4);
   var data = this.data;
   var offset = this.offset;
-  data[offset++] = (value >> 24) & 0xFF;
-  data[offset++] = (value >> 16) & 0xFF;
-  data[offset++] = (value >> 8) & 0xFF;
+  data[offset++] = (value >>> 24) & 0xFF;
+  data[offset++] = (value >>> 16) & 0xFF;
+  data[offset++] = (value >>> 8) & 0xFF;
   data[offset++] = value & 0xFF;
   this.offset = offset;
 };
@@ -257,7 +257,7 @@ wtf.io.Buffer.prototype.writeUint16 = function(value) {
   this.ensureCapacity_(2);
   var data = this.data;
   var offset = this.offset;
-  data[offset++] = (value >> 8) & 0xFF;
+  data[offset++] = (value >>> 8) & 0xFF;
   data[offset++] = value & 0xFF;
   this.offset = offset;
 };
@@ -288,9 +288,9 @@ wtf.io.Buffer.prototype.writeUint32 = function(value) {
   this.ensureCapacity_(4);
   var data = this.data;
   var offset = this.offset;
-  data[offset++] = (value >> 24) & 0xFF;
-  data[offset++] = (value >> 16) & 0xFF;
-  data[offset++] = (value >> 8) & 0xFF;
+  data[offset++] = (value >>> 24) & 0xFF;
+  data[offset++] = (value >>> 16) & 0xFF;
+  data[offset++] = (value >>> 8) & 0xFF;
   data[offset++] = value & 0xFF;
   this.offset = offset;
 };

--- a/src/wtf/ui/rangepainter.js
+++ b/src/wtf/ui/rangepainter.js
@@ -96,11 +96,6 @@ wtf.ui.RangePainter.DrawStyle = {
   SCOPE: 0,
 
   /**
-   * Draw lines as instances - smaller vertically aligned bars.
-   */
-  INSTANCE: 1,
-
-  /**
    * Draw lines as time spans - thin bars.
    */
   TIME_SPAN: 2
@@ -211,9 +206,6 @@ wtf.ui.RangePainter.prototype.endRenderingRanges = function(
   var labelBackground = null;
   var labelForeground = '#FFFFFF';
   switch (this.drawStyle_) {
-    case wtf.ui.RangePainter.DrawStyle.INSTANCE:
-      insetH = rowHeight * 0.3;
-      break;
     case wtf.ui.RangePainter.DrawStyle.TIME_SPAN:
       insetY = insetH = rowHeight / 4;
       labelBackground = '#FFFFFF';

--- a/src/wtf/ui/rangerenderer.js
+++ b/src/wtf/ui/rangerenderer.js
@@ -48,14 +48,15 @@ wtf.ui.RangeRenderer.prototype.reset = function(width) {
     this.buffer_ = new Float32Array(width * 4);
     this.width_ = width;
   }
+  var buff = this.buffer_;
   for (var i = 0; i < width; i++) {
-    this.buffer_[4 * i + 0] = 0;
-    this.buffer_[4 * i + 1] = 0;
-    this.buffer_[4 * i + 2] = 0;
+    buff[4 * i + 0] = 0;
+    buff[4 * i + 1] = 0;
+    buff[4 * i + 2] = 0;
     // Initializing alpha to a very small value allows a uniform
     // un-premultiply in getPixels because we won't have to worry about
     // dividing by 0.
-    this.buffer_[4 * i + 3] = .00001;
+    buff[4 * i + 3] = .00001;
   }
 };
 
@@ -95,10 +96,11 @@ wtf.ui.RangeRenderer.prototype.drawRange = function(left, right, color, alpha) {
  * @private
  */
 wtf.ui.RangeRenderer.prototype.setPx_ = function(x, color, alpha) {
-  this.buffer_[x * 4 + 0] = alpha * (color & 0xFF);
-  this.buffer_[x * 4 + 1] = alpha * ((color >> 8) & 0xFF);
-  this.buffer_[x * 4 + 2] = alpha * ((color >> 16) & 0xFF);
-  this.buffer_[x * 4 + 3] = alpha;
+  var buff = this.buffer_;
+  buff[x * 4 + 0] = alpha * (color & 0xFF);
+  buff[x * 4 + 1] = alpha * ((color >>> 8) & 0xFF);
+  buff[x * 4 + 2] = alpha * ((color >>> 16) & 0xFF);
+  buff[x * 4 + 3] = alpha;
 };
 
 
@@ -111,10 +113,11 @@ wtf.ui.RangeRenderer.prototype.setPx_ = function(x, color, alpha) {
  * @private
  */
 wtf.ui.RangeRenderer.prototype.accumPx_ = function(x, d, color, alpha) {
-  this.buffer_[x * 4 + 0] += d * alpha * (color & 0xFF);
-  this.buffer_[x * 4 + 1] += d * alpha * ((color >> 8) & 0xFF);
-  this.buffer_[x * 4 + 2] += d * alpha * ((color >> 16) & 0xFF);
-  this.buffer_[x * 4 + 3] += d * alpha;
+  var buff = this.buffer_;
+  buff[x * 4 + 0] += d * alpha * (color & 0xFF);
+  buff[x * 4 + 1] += d * alpha * ((color >>> 8) & 0xFF);
+  buff[x * 4 + 2] += d * alpha * ((color >>> 16) & 0xFF);
+  buff[x * 4 + 3] += d * alpha;
 };
 
 


### PR DESCRIPTION
This merges the scope and instance drawing code into a single loop and
adds the required methods to the event iterator to support this. In the
common case now (cached colors and no label) there are no event type
lookups required and things are about 30% faster. By having just a single
loop it will make it easier to add the 'merged' drawing in a future CL
(which can draw about 9million events in 30ms instead of 1.5s).

Fixed an issue with the zone painter not being tall enough to hit test
instance events properly.
