### PR TITLE
Speeding up event statistics.

### DIFF
--- a/bin/diff.js
+++ b/bin/diff.js
@@ -50,8 +50,8 @@ function runTool(platform, args) {
   }
 
   // Build event data tables.
-  var table1 = new wtf.db.EventStatistics(db1, filter);
-  var table2 = new wtf.db.EventStatistics(db2, filter);
+  var table1 = new wtf.db.EventStatistics(db1).getTable().filter(filter);
+  var table2 = new wtf.db.EventStatistics(db2).getTable().filter(filter);
 
   // Grab all event types from each table and divide by type.
   var allInstanceEntryNames = wtf.db.EventStatistics.getAllEventTypeNames(

--- a/src/wtf/app/ui/documentview.js
+++ b/src/wtf/app/ui/documentview.js
@@ -85,7 +85,8 @@ wtf.app.ui.DocumentView = function(parentElement, dom, doc) {
    * @type {!wtf.db.HealthInfo}
    * @private
    */
-  this.healthInfo_ = new wtf.db.HealthInfo(doc.getDatabase());
+  this.healthInfo_ = new wtf.db.HealthInfo(
+      doc.getDatabase(), this.selection_.getFullStatistics());
 
   // Rebuild health info.
   // We try to pass in our event statistics if we can (no filter).
@@ -93,11 +94,8 @@ wtf.app.ui.DocumentView = function(parentElement, dom, doc) {
   // other handlers setup by the UI.
   var db = doc.getDatabase();
   db.addListener(wtf.events.EventType.INVALIDATED, function() {
-    var eventStatistics = null;
-    if (!this.selection_.hasFilterSpecified()) {
-      eventStatistics = this.selection_.computeEventStatistics();
-    }
-    this.healthInfo_ = new wtf.db.HealthInfo(db, eventStatistics);
+    this.healthInfo_ = new wtf.db.HealthInfo(
+        db, this.selection_.getFullStatistics());
   }, this);
 
   /**

--- a/src/wtf/app/ui/statusbar.js
+++ b/src/wtf/app/ui/statusbar.js
@@ -123,8 +123,8 @@ wtf.app.ui.Statusbar.prototype.update_ = function() {
     totalEventCount += eventList.getTotalEventCount();
   }
 
-  var table = selection.computeEventStatistics();
-  var filteredEventCount = table.getFilteredEventCount();
+  var table = selection.getSelectionStatistics();
+  var filteredEventCount = table.getEventCount();
 
   var selectionCounts = [
     filteredEventCount,

--- a/src/wtf/app/ui/tracks/statisticstablesource.js
+++ b/src/wtf/app/ui/tracks/statisticstablesource.js
@@ -56,15 +56,15 @@ goog.inherits(
 
 /**
  * Updates the source with the given event statistics table.
- * @param {!wtf.db.EventStatistics} eventStatistics Event statistics table.
+ * @param {!wtf.db.EventStatistics.Table} table Event statistics table.
  * @param {wtf.db.SortMode} sortMode Table sort mode.
  */
 wtf.app.ui.tracks.StatisticsTableSource.prototype.update = function(
-    eventStatistics, sortMode) {
+    table, sortMode) {
   this.sortMode_ = sortMode;
 
   var allRows = [];
-  eventStatistics.forEach(function(entry) {
+  table.forEach(function(entry) {
     // Ignore system events.
     if (entry.eventType.flags & wtf.data.EventFlag.INTERNAL) {
       return;

--- a/src/wtf/app/ui/tracks/trackinfobar.js
+++ b/src/wtf/app/ui/tracks/trackinfobar.js
@@ -209,7 +209,7 @@ wtf.app.ui.tracks.TrackInfoBar.prototype.layoutInternal = function() {
  */
 wtf.app.ui.tracks.TrackInfoBar.prototype.updateInfo_ = function() {
   var beginTime = wtf.now();
-  var table = this.selection_.computeEventStatistics();
+  var table = this.selection_.getSelectionStatistics();
   var updateDuration = wtf.now() - beginTime;
   //goog.global.console.log('update info', updateDuration);
 

--- a/src/wtf/db/healthinfo.js
+++ b/src/wtf/db/healthinfo.js
@@ -15,7 +15,6 @@ goog.provide('wtf.db.HealthInfo');
 goog.provide('wtf.db.HealthWarning');
 
 goog.require('wtf.data.EventClass');
-goog.require('wtf.db.EventStatistics');
 goog.require('wtf.db.ScopeEventDataEntry');
 
 
@@ -26,13 +25,11 @@ goog.require('wtf.db.ScopeEventDataEntry');
  * to track things like tracing overhead.
  *
  * @param {!wtf.db.Database} db Database.
- * @param {wtf.db.EventStatistics=} opt_eventStatistics An event statistics
- *     table to reuse for generating the health report. If not provided a new
- *     one is computed. If you're already computing a table on startup, pass it
- *     in here.
+ * @param {!wtf.db.EventStatistics.Table} table An event statistics
+ *     table to use for generating the health report.
  * @constructor
  */
-wtf.db.HealthInfo = function(db, opt_eventStatistics) {
+wtf.db.HealthInfo = function(db, table) {
   /**
    * Whether the trace is 'bad'.
    * @type {boolean}
@@ -68,8 +65,7 @@ wtf.db.HealthInfo = function(db, opt_eventStatistics) {
    */
   this.warnings_ = [];
 
-  var eventStatistics = opt_eventStatistics || new wtf.db.EventStatistics(db);
-  this.analyzeStatistics_(db, eventStatistics);
+  this.analyzeStatistics_(db, table);
 };
 
 
@@ -124,10 +120,10 @@ wtf.db.HealthInfo.prototype.getWarnings = function() {
 /**
  * Analyzes event statistics to try to gauge the badness of the database.
  * @param {!wtf.db.Database} db Database.
- * @param {!wtf.db.EventStatistics} eventStatistics Event statistics.
+ * @param {!wtf.db.EventStatistics.Table} table Event statistics table.
  * @private
  */
-wtf.db.HealthInfo.prototype.analyzeStatistics_ = function(db, eventStatistics) {
+wtf.db.HealthInfo.prototype.analyzeStatistics_ = function(db, table) {
   var counts = {
     totalCount: 0,
     frameCount: 0,
@@ -164,7 +160,7 @@ wtf.db.HealthInfo.prototype.analyzeStatistics_ = function(db, eventStatistics) {
   }
 
   // Generate counts.
-  var entries = eventStatistics.getEntries();
+  var entries = table.getEntries();
   for (var n = 0; n < entries.length; n++) {
     var entry = entries[n];
     var eventType = entry.getEventType();


### PR DESCRIPTION
This flips the way the event statistics tables work around a bit to allow
for 'free' filtering and caching of the full table. The only time a new
table is generated is when the selection changes, and only when it's not
a select-all.

With this, filtering on even 9 million entry dbs is instant (so long as
the paint times are low).

Fixes #283.
