### PR TITLE
Draw grey proxy boxes for very thin scope stacks.

### DIFF
--- a/src/wtf/db/eventiterator.js
+++ b/src/wtf/db/eventiterator.js
@@ -375,7 +375,17 @@ wtf.db.EventIterator.prototype.getParentEndTime = function() {
  * @return {number} Scope depth.
  */
 wtf.db.EventIterator.prototype.getDepth = function() {
-  return this.eventData_[this.offset_ + wtf.db.EventStruct.DEPTH];
+  return this.eventData_[this.offset_ + wtf.db.EventStruct.DEPTH] & 0xFFFF;
+};
+
+
+/**
+ * Gets the maximum depth (distance from root) of an descendant of this
+ * event.
+ * @return {number} Scope depth.
+ */
+wtf.db.EventIterator.prototype.getMaxDescendantDepth = function() {
+  return this.eventData_[this.offset_ + wtf.db.EventStruct.DEPTH] >>> 16;
 };
 
 

--- a/src/wtf/db/eventstruct.js
+++ b/src/wtf/db/eventstruct.js
@@ -41,7 +41,13 @@ wtf.db.EventStruct = {
   PARENT: 2,
 
   /**
-   * Event depth, where 0 is at the root.
+   * Event depth, where 0 is at the root, and a max descendant depth.
+   * The depth is in the lower 16 bits and the max descendant depth is in the
+   * upper.
+   * <code>
+   * var depth = data[DEPTH] & 0xFFFF;
+   * var descendantDepth = data[DEPTH] >>> 16;
+   * </code>
    */
   DEPTH: 3,
 

--- a/src/wtf/ui/errordialog.js
+++ b/src/wtf/ui/errordialog.js
@@ -51,7 +51,9 @@ wtf.ui.ErrorDialog = function(message, detail, opt_dom) {
   var eh = this.getHandler();
   eh.listen(
       this.getChildElement(goog.getCssName('buttonClose')),
-      goog.events.EventType.CLICK, this.close, false, this);
+      goog.events.EventType.CLICK, function() {
+        this.close();
+      }, false, this);
 };
 goog.inherits(wtf.ui.ErrorDialog, wtf.ui.Dialog);
 


### PR DESCRIPTION
This makes drawing the main view dependent on screen size, not trace size.
Fixes #272.
