### PR TITLE
Adding plumbing to detect and display units of measure in a database.

### DIFF
--- a/src/wtf/app/ui/nav/navbar.js
+++ b/src/wtf/app/ui/nav/navbar.js
@@ -280,7 +280,9 @@ wtf.app.ui.nav.Navbar.prototype.databaseInvalidated_ = function() {
   var firstEventTime = db.getFirstEventTime();
   var lastEventTime = db.getLastEventTime();
   for (var n = 0; n < this.timePainters_.length; n++) {
-    this.timePainters_[n].setTimeRange(firstEventTime, lastEventTime);
+    var painter = this.timePainters_[n];
+    painter.setTimeRange(firstEventTime, lastEventTime);
+    painter.setUnits(db.getUnits());
   }
   this.requestRepaint();
 };

--- a/src/wtf/app/ui/query/querypanel.js
+++ b/src/wtf/app/ui/query/querypanel.js
@@ -363,7 +363,9 @@ wtf.app.ui.query.QueryPanel.prototype.issueQuery_ = function(expression) {
   // Update the table.
   if (result instanceof wtf.db.EventIterator) {
     // Show using table.
-    this.table_.setSource(new wtf.app.ui.query.QueryTableSource(result));
+    var tableSource = new wtf.app.ui.query.QueryTableSource(result);
+    tableSource.setUnits(this.db_.getUnits());
+    this.table_.setSource(tableSource);
   } else {
     // Show simple result.
   }

--- a/src/wtf/app/ui/query/querytablesource.js
+++ b/src/wtf/app/ui/query/querytablesource.js
@@ -13,9 +13,9 @@
 
 goog.provide('wtf.app.ui.query.QueryTableSource');
 
+goog.require('wtf.db.Unit');
 goog.require('wtf.events');
 goog.require('wtf.ui.VirtualTableSource');
-goog.require('wtf.util');
 
 
 
@@ -30,6 +30,13 @@ wtf.app.ui.query.QueryTableSource = function(result) {
   goog.base(this);
 
   /**
+   * Display units.
+   * @type {wtf.db.Unit}
+   * @private
+   */
+  this.units_ = wtf.db.Unit.TIME_MILLISECONDS;
+
+  /**
    * All rows.
    * @type {!wtf.db.EventIterator}
    * @private
@@ -38,6 +45,15 @@ wtf.app.ui.query.QueryTableSource = function(result) {
   this.setRowCount(result.getCount());
 };
 goog.inherits(wtf.app.ui.query.QueryTableSource, wtf.ui.VirtualTableSource);
+
+
+/**
+ * Sets the display units.
+ * @param {wtf.db.Unit} value Display units.
+ */
+wtf.app.ui.query.QueryTableSource.prototype.setUnits = function(value) {
+  this.units_ = value;
+};
 
 
 /**
@@ -96,7 +112,7 @@ wtf.app.ui.query.QueryTableSource.prototype.paintRowRange = function(
 
     var x = gutterWidth + charWidth;
     if (columnTime >= 0) {
-      var columnTimeText = wtf.util.formatTime(columnTime);
+      var columnTimeText = wtf.db.Unit.format(columnTime, this.units_);
       ctx.fillText(
           columnTimeText,
           x + columnTimeWidth - (columnTimeText.length * charWidth),
@@ -158,7 +174,7 @@ wtf.app.ui.query.QueryTableSource.prototype.getInfoString = function(
     row, x, bounds) {
   var it = this.result_;
   it.seek(row);
-  return it.getInfoString();
+  return it.getInfoString(this.units_);
 };
 
 

--- a/src/wtf/app/ui/statusbar.js
+++ b/src/wtf/app/ui/statusbar.js
@@ -17,6 +17,7 @@ goog.require('goog.events.EventType');
 goog.require('goog.soy');
 goog.require('goog.style');
 goog.require('wtf.app.ui.statusbar');
+goog.require('wtf.db.Unit');
 goog.require('wtf.events');
 goog.require('wtf.events.EventType');
 goog.require('wtf.events.Keyboard');
@@ -106,6 +107,7 @@ wtf.app.ui.Statusbar.prototype.update_ = function() {
   var dom = this.getDom();
   var db = this.documentView_.getDatabase();
   var selection = this.documentView_.getSelection();
+  var units = db.getUnits();
 
   if (!db.getLastEventTime()) {
     goog.style.setElementShown(this.getRootElement(), false);
@@ -132,12 +134,12 @@ wtf.app.ui.Statusbar.prototype.update_ = function() {
   ].join('/');
   dom.setTextContent(this.divs_.selectionCounts, selectionCounts);
 
-  var totalDuration = wtf.util.formatTime(lastEventTime - firstEventTime);
+  var totalDuration = wtf.db.Unit.format(lastEventTime - firstEventTime, units);
   if (selection.hasTimeRangeSpecified()) {
     var selectionTimeStart = selection.getTimeStart();
     var selectionTimeEnd = selection.getTimeEnd();
     dom.setTextContent(this.divs_.selectionTimes, [
-      wtf.util.formatTime(selectionTimeEnd - selectionTimeStart),
+      wtf.db.Unit.format(selectionTimeEnd - selectionTimeStart, units),
       totalDuration
     ].join('/'));
   } else {
@@ -147,8 +149,12 @@ wtf.app.ui.Statusbar.prototype.update_ = function() {
     ].join('/'));
   }
 
-  dom.setTextContent(this.divs_.timeRange, [
-    wtf.util.formatWallTime(timebase + firstEventTime),
-    wtf.util.formatWallTime(timebase + lastEventTime)
-  ].join('-'));
+  if (units == wtf.db.Unit.TIME_MILLISECONDS) {
+    dom.setTextContent(this.divs_.timeRange, [
+      wtf.util.formatWallTime(timebase + firstEventTime),
+      wtf.util.formatWallTime(timebase + lastEventTime)
+    ].join('-'));
+  } else {
+    dom.setTextContent(this.divs_.timeRange, '');
+  }
 };

--- a/src/wtf/app/ui/tracks/statisticstablesource.js
+++ b/src/wtf/app/ui/tracks/statisticstablesource.js
@@ -17,10 +17,10 @@ goog.require('wtf.data.EventFlag');
 goog.require('wtf.db.InstanceEventDataEntry');
 goog.require('wtf.db.ScopeEventDataEntry');
 goog.require('wtf.db.SortMode');
+goog.require('wtf.db.Unit');
 goog.require('wtf.events');
 goog.require('wtf.ui.ModifierKey');
 goog.require('wtf.ui.VirtualTableSource');
-goog.require('wtf.util');
 
 
 
@@ -49,9 +49,25 @@ wtf.app.ui.tracks.StatisticsTableSource = function() {
    * @private
    */
   this.sortMode_ = wtf.db.SortMode.TOTAL_TIME;
+
+  /**
+   * Display units.
+   * @type {wtf.db.Unit}
+   * @private
+   */
+  this.units_ = wtf.db.Unit.TIME_MILLISECONDS;
 };
 goog.inherits(
     wtf.app.ui.tracks.StatisticsTableSource, wtf.ui.VirtualTableSource);
+
+
+/**
+ * Sets the display units.
+ * @param {wtf.db.Unit} value Display units.
+ */
+wtf.app.ui.tracks.StatisticsTableSource.prototype.setUnits = function(value) {
+  this.units_ = value;
+};
 
 
 /**
@@ -105,9 +121,9 @@ wtf.app.ui.tracks.StatisticsTableSource.prototype.paintRowRange = function(
     var meanTime = null;
     var content = '';
     if (entry instanceof wtf.db.ScopeEventDataEntry) {
-      totalTime = wtf.util.formatSmallTime(entry.getTotalTime());
-      userTime = wtf.util.formatSmallTime(entry.getUserTime());
-      meanTime = wtf.util.formatSmallTime(entry.getMeanTime());
+      totalTime = wtf.db.Unit.format(entry.getTotalTime(), this.units_, true);
+      userTime = wtf.db.Unit.format(entry.getUserTime(), this.units_, true);
+      meanTime = wtf.db.Unit.format(entry.getMeanTime(), this.units_, true);
       content =
           entry.getCount() + ', ' +
           totalTime + ' t, ' +
@@ -201,9 +217,25 @@ wtf.app.ui.tracks.StatisticsTableSource.prototype.getInfoString = function(
   lines.push(eventType.getName());
   lines.push('Count: ' + entry.getCount());
   if (entry instanceof wtf.db.ScopeEventDataEntry) {
-    lines.push('Total time: ' + wtf.util.formatSmallTime(entry.getTotalTime()));
-    lines.push('User time: ' + wtf.util.formatSmallTime(entry.getUserTime()));
-    lines.push('Mean time: ' + wtf.util.formatSmallTime(entry.getMeanTime()));
+    var unitName;
+    switch (this.units_) {
+      default:
+      case wtf.db.Unit.TIME_MILLISECONDS:
+        unitName = 'time';
+        break;
+      case wtf.db.Unit.SIZE_KILOBYTES:
+        unitName = 'size';
+        break;
+      case wtf.db.Unit.COUNT:
+        unitName = 'value';
+        break;
+    }
+    lines.push('Total ' + unitName + ': ' +
+        wtf.db.Unit.format(entry.getTotalTime(), this.units_));
+    lines.push('User ' + unitName + ': ' +
+        wtf.db.Unit.format(entry.getUserTime(), this.units_));
+    lines.push('Mean ' + unitName + ': ' +
+        wtf.db.Unit.format(entry.getMeanTime(), this.units_));
   }
 
   return lines.join('\n');

--- a/src/wtf/app/ui/tracks/trackinfobar.js
+++ b/src/wtf/app/ui/tracks/trackinfobar.js
@@ -213,5 +213,8 @@ wtf.app.ui.tracks.TrackInfoBar.prototype.updateInfo_ = function() {
   var updateDuration = wtf.now() - beginTime;
   //goog.global.console.log('update info', updateDuration);
 
+  var db = this.tracksPanel_.getDocumentView().getDatabase();
+  this.tableSource_.setUnits(db.getUnits());
+
   this.tableSource_.update(table, this.sortMode_);
 };

--- a/src/wtf/app/ui/tracks/trackspanel.js
+++ b/src/wtf/app/ui/tracks/trackspanel.js
@@ -408,6 +408,7 @@ wtf.app.ui.tracks.TracksPanel.prototype.viewportChanged_ = function() {
   for (var n = 0; n < this.timePainters_.length; n++) {
     var painter = this.timePainters_[n];
     painter.setTimeRange(timeLeft, timeRight);
+    painter.setUnits(db.getUnits());
   }
 
   // Update the tooltip, if it's visible.

--- a/src/wtf/app/ui/tracks/zonepainter.js
+++ b/src/wtf/app/ui/tracks/zonepainter.js
@@ -315,7 +315,7 @@ wtf.app.ui.tracks.ZonePainter.prototype.onClickInternal =
 wtf.app.ui.tracks.ZonePainter.prototype.getInfoStringInternal =
     function(x, y, bounds) {
   var it = this.hitTest_(x, y, bounds);
-  return it ? it.getInfoString() : undefined;
+  return it ? it.getInfoString(this.units) : undefined;
 };
 
 

--- a/src/wtf/data/variable.js
+++ b/src/wtf/data/variable.js
@@ -195,6 +195,15 @@ wtf.data.Variable.parseSignature = function(signature) {
   // Trim.
   signature = goog.string.trim(signature);
 
+  // Trim interior whitespace up until the first (.
+  // This allows poorly-formed names to still work.
+  var i = signature.indexOf('(');
+  if (i != -1) {
+    signature = signature.substr(0, i).replace(/ /g, '') + signature.substr(i);
+  } else {
+    signature = signature.replace(/ /g, '');
+  }
+
   // Split signature.
   // 'a.b.c(<params>)'
   // ["a.b.c(t1 x, t1 y, t3 z@3)", "a.b.c", "(<params>)", "<params>"]

--- a/src/wtf/db/datasource.js
+++ b/src/wtf/db/datasource.js
@@ -18,6 +18,7 @@ goog.provide('wtf.db.PresentationHint');
 goog.require('goog.Disposable');
 goog.require('goog.asserts');
 goog.require('wtf.data.formats.FileFlags');
+goog.require('wtf.db.Unit');
 
 
 
@@ -135,6 +136,13 @@ wtf.db.DataSource = function(db) {
   this.presentationHints_ = 0;
 
   /**
+   * Units used in the database.
+   * @type {wtf.db.Unit}
+   * @private
+   */
+  this.units_ = wtf.db.Unit.TIME_MILLISECONDS;
+
+  /**
    * File metadata.
    * @type {!Object}
    * @private
@@ -218,6 +226,15 @@ wtf.db.DataSource.prototype.getPresentationHints = function() {
 
 
 /**
+ * Gets the unit of measurement the data is in.
+ * @return {wtf.db.Unit} Unit of measurement.
+ */
+wtf.db.DataSource.prototype.getUnits = function() {
+  return this.units_;
+};
+
+
+/**
  * Gets embedded file metadata.
  * @return {!Object} Metadata.
  */
@@ -259,22 +276,28 @@ wtf.db.DataSource.prototype.start = goog.nullFunction;
  * @param {!wtf.data.ContextInfo} contextInfo Context information.
  * @param {number} flags A bitmask of {@see wtf.data.formats.FileFlags} values.
  * @param {number} presentationHints Bitmask of presentation hints.
+ * @param {wtf.db.Unit} units Unit of measurement.
  * @param {!Object} metadata File metadata.
  * @param {number} timebase Time base for all time values read.
  * @param {number} timeDelay Estimated time delay.
+ * @return {boolean} Whether the initialization was successful.
  * @protected
  */
 wtf.db.DataSource.prototype.initialize = function(
-    contextInfo, flags, presentationHints, metadata, timebase, timeDelay) {
+    contextInfo, flags, presentationHints, units, metadata, timebase,
+    timeDelay) {
   goog.asserts.assert(!this.isInitialized_);
   this.isInitialized_ = true;
 
   this.contextInfo_ = contextInfo;
   this.flags_ = flags;
   this.presentationHints_ = presentationHints;
+  this.units_ = units;
   this.metadata_ = metadata;
   this.timebase_ = timebase;
   this.timeDelay_ = timeDelay;
+
+  return this.db_.sourceInitialized(this);
 };
 
 
@@ -290,6 +313,9 @@ goog.exportProperty(
 goog.exportProperty(
     wtf.db.DataSource.prototype, 'getPresentationHints',
     wtf.db.DataSource.prototype.getPresentationHints);
+goog.exportProperty(
+    wtf.db.DataSource.prototype, 'getUnits',
+    wtf.db.DataSource.prototype.getUnits);
 goog.exportProperty(
     wtf.db.DataSource.prototype, 'getMetadata',
     wtf.db.DataSource.prototype.getMetadata);

--- a/src/wtf/db/eventiterator.js
+++ b/src/wtf/db/eventiterator.js
@@ -14,6 +14,7 @@
 goog.provide('wtf.db.EventIterator');
 
 goog.require('wtf.db.EventStruct');
+goog.require('wtf.db.Unit');
 goog.require('wtf.util');
 
 
@@ -501,16 +502,18 @@ wtf.db.EventIterator.prototype.getOwnDuration = function() {
 
 /**
  * Gets an informative string about the current event.
+ * @param {wtf.db.Unit=} opt_units Units to display times in.
  * @return {string?} Info string.
  */
-wtf.db.EventIterator.prototype.getInfoString = function() {
+wtf.db.EventIterator.prototype.getInfoString = function(opt_units) {
   if (this.done()) {
     return null;
   }
+  var units = goog.isDef(opt_units) ? opt_units : wtf.db.Unit.TIME_MILLISECONDS;
   if (this.isScope()) {
-    return this.getScopeInfoString_();
+    return this.getScopeInfoString_(units);
   } else if (this.isInstance()) {
-    return this.getInstanceInfoString_();
+    return this.getInstanceInfoString_(units);
   }
   return null;
 };
@@ -518,14 +521,15 @@ wtf.db.EventIterator.prototype.getInfoString = function() {
 
 /**
  * Gets an informative string about the current scope event.
+ * @param {wtf.db.Unit} units Units to display times in.
  * @return {string} Info string.
  * @private
  */
-wtf.db.EventIterator.prototype.getScopeInfoString_ = function() {
-  var totalTime = wtf.util.formatTime(this.getTotalDuration());
+wtf.db.EventIterator.prototype.getScopeInfoString_ = function(units) {
+  var totalTime = wtf.db.Unit.format(this.getTotalDuration(), units);
   var times = totalTime;
   if (this.getTotalDuration() - this.getOwnDuration()) {
-    var ownTime = wtf.util.formatTime(this.getOwnDuration());
+    var ownTime = wtf.db.Unit.format(this.getOwnDuration(), units);
     times += ' (' + ownTime + ')';
   }
 
@@ -545,10 +549,11 @@ wtf.db.EventIterator.prototype.getScopeInfoString_ = function() {
 
 /**
  * Gets an informative string about the current instance event.
+ * @param {wtf.db.Unit} units Units to display times in.
  * @return {string} Info string.
  * @private
  */
-wtf.db.EventIterator.prototype.getInstanceInfoString_ = function() {
+wtf.db.EventIterator.prototype.getInstanceInfoString_ = function(units) {
   var lines = [];
 
   var type = this.getType();

--- a/src/wtf/db/healthinfo.js
+++ b/src/wtf/db/healthinfo.js
@@ -25,11 +25,11 @@ goog.require('wtf.db.ScopeEventDataEntry');
  * to track things like tracing overhead.
  *
  * @param {!wtf.db.Database} db Database.
- * @param {!wtf.db.EventStatistics.Table} table An event statistics
+ * @param {wtf.db.EventStatistics.Table=} opt_table An event statistics
  *     table to use for generating the health report.
  * @constructor
  */
-wtf.db.HealthInfo = function(db, table) {
+wtf.db.HealthInfo = function(db, opt_table) {
   /**
    * Whether the trace is 'bad'.
    * @type {boolean}
@@ -65,7 +65,9 @@ wtf.db.HealthInfo = function(db, table) {
    */
   this.warnings_ = [];
 
-  this.analyzeStatistics_(db, table);
+  if (opt_table) {
+    this.analyzeStatistics_(db, opt_table);
+  }
 };
 
 

--- a/src/wtf/db/sources/binarydatasource.js
+++ b/src/wtf/db/sources/binarydatasource.js
@@ -23,6 +23,7 @@ goog.require('wtf.db.ArgumentData');
 goog.require('wtf.db.DataSource');
 goog.require('wtf.db.EventType');
 goog.require('wtf.db.TimeRange');
+goog.require('wtf.db.Unit');
 goog.require('wtf.io.EventType');
 
 
@@ -259,7 +260,11 @@ wtf.db.sources.BinaryDataSource.prototype.readTraceHeader_ =
 
   // Initialize the trace source.
   // Only call when all other parsing has been successful.
-  this.initialize(contextInfo, flags, 0, metadata, timebase, timeDelay);
+  if (!this.initialize(
+      contextInfo, flags, 0, wtf.db.Unit.TIME_MILLISECONDS, metadata,
+      timebase, timeDelay)) {
+    return false;
+  }
 
   // Add builtin events for this version.
   switch (formatVersion) {

--- a/src/wtf/db/sources/callsdatasource.js
+++ b/src/wtf/db/sources/callsdatasource.js
@@ -21,6 +21,7 @@ goog.require('wtf.data.formats.FileFlags');
 goog.require('wtf.db.DataSource');
 goog.require('wtf.db.EventType');
 goog.require('wtf.db.PresentationHint');
+goog.require('wtf.db.Unit');
 goog.require('wtf.io');
 goog.require('wtf.util');
 
@@ -121,13 +122,23 @@ wtf.db.sources.CallsDataSource.prototype.start = function() {
   }
   var attributes = metadata['attributes'] || [];
 
+  // Infer units from attributes.
+  var units = wtf.db.Unit.COUNT;
+  if (attributes.length) {
+    var unitsStr = attributes[0]['units'];
+    units = wtf.db.Unit.parse(unitsStr);
+  }
+
   // Assume we are always special. In the future the file can specify this.
   var presentationHints = 0;
   presentationHints |= wtf.db.PresentationHint.NO_RENDER_DATA;
   presentationHints |= wtf.db.PresentationHint.BARE;
 
-  this.initialize(
-      contextInfo, flags, presentationHints, metadata, timebase, timeDelay);
+  if (!this.initialize(
+      contextInfo, flags, presentationHints, units, metadata,
+      timebase, timeDelay)) {
+    return false;
+  }
 
   // Setup some builtin event types.
   var leaveEventType = eventTypeTable.defineType(

--- a/src/wtf/db/sources/jsondatasource.js
+++ b/src/wtf/db/sources/jsondatasource.js
@@ -23,6 +23,7 @@ goog.require('wtf.data.formats.JsonTrace');
 goog.require('wtf.db.ArgumentData');
 goog.require('wtf.db.DataSource');
 goog.require('wtf.db.EventType');
+goog.require('wtf.db.Unit');
 
 
 
@@ -321,9 +322,9 @@ wtf.db.sources.JsonDataSource.prototype.parseHeader_ = function(entry) {
   var contextInfo = new wtf.data.ScriptContextInfo();
 
   var timeDelay = db.computeTimeDelay(timebase);
-  this.initialize(contextInfo, flags, 0, metadata, timebase, timeDelay);
-
-  return true;
+  return this.initialize(
+      contextInfo, flags, 0, wtf.db.Unit.TIME_MILLISECONDS, metadata,
+      timebase, timeDelay);
 };
 
 

--- a/src/wtf/db/unit.js
+++ b/src/wtf/db/unit.js
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2013 Google, Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+/**
+ * @fileoverview Measurement unit.
+ *
+ * @author benvanik@google.com (Ben Vanik)
+ */
+
+goog.provide('wtf.db.Unit');
+
+goog.require('goog.asserts');
+goog.require('wtf.util');
+
+
+/**
+ * The unit of measure of values in the database.
+ * @enum {number}
+ */
+wtf.db.Unit = {
+  /**
+   * Each unit value is 1 millisecond.
+   */
+  TIME_MILLISECONDS: 0,
+
+  /**
+   * Each unit value is 1000 bytes.
+   */
+  SIZE_KILOBYTES: 1,
+
+  /**
+   * Each unit value is a count.
+   */
+  COUNT: 2
+};
+
+
+/**
+ * Gets the unit type from a string value.
+ * This will fallback to returning microseconds if the value cannot be parsed,
+ * as they are generally still usable.
+ * @param {string?} value String value.
+ * @return {wtf.db.Unit} Parsed unit value.
+ */
+wtf.db.Unit.parse = function(value) {
+  // Default value is time.
+  if (!value || !value.length) {
+    return wtf.db.Unit.TIME_MILLISECONDS;
+  }
+
+  switch (value) {
+    case 'microseconds':
+      return wtf.db.Unit.TIME_MILLISECONDS;
+    case 'bytes':
+      return wtf.db.Unit.SIZE_KILOBYTES;
+    case 'count':
+      return wtf.db.Unit.COUNT;
+  }
+
+  // Shouldn't get here - may really be unknown.
+  goog.asserts.fail('Unknown unit type: ' + value);
+  return wtf.db.Unit.TIME_MILLISECONDS;
+};
+
+
+/**
+ * Formats a value to a human-readable string.
+ * @param {number} value Value.
+ * @param {wtf.db.Unit} units Value units.
+ * @param {boolean=} opt_small Prefer a smaller display value, if possible.
+ * @return {string} Human-readable string value.
+ */
+wtf.db.Unit.format = function(value, units, opt_small) {
+  // TODO(benvanik): more modes? LONG/MEDIUM/SMALL?
+  if (units == wtf.db.Unit.TIME_MILLISECONDS) {
+    return opt_small ?
+        wtf.util.formatSmallTime(value) : wtf.util.formatTime(value);
+  } else if (units == wtf.db.Unit.SIZE_KILOBYTES) {
+    var places = opt_small ? 0 : 3;
+    value = Math.round(value * 1000);
+    if (value == 0) {
+      return '0b';
+    } else if (value < 1024) {
+      return value + 'b';
+    } else if (value < 1024 * 1024) {
+      return (value / 1024).toFixed(places) + 'kb';
+    } else {
+      return (value / (1024 * 1024)).toFixed(places) + 'mb';
+    }
+  } else if (units == wtf.db.Unit.COUNT) {
+    var places = opt_small ? 0 : 3;
+    value = Math.round(value * 1000);
+    if (value == 0) {
+      return '0';
+    } else if (value < 1000) {
+      return String(value);
+    } else if (value < 1000 * 1000) {
+      return (value / 1000).toFixed(places) + 'k';
+    } else {
+      return (value / (1000 * 1000)).toFixed(places) + 'm';
+    }
+  }
+  return String(value);
+};

--- a/src/wtf/ui/rulerpainter.js
+++ b/src/wtf/ui/rulerpainter.js
@@ -13,9 +13,9 @@
 
 goog.provide('wtf.ui.RulerPainter');
 
+goog.require('wtf.db.Unit');
 goog.require('wtf.math');
 goog.require('wtf.ui.TimePainter');
-goog.require('wtf.util');
 
 
 
@@ -41,6 +41,13 @@ wtf.ui.RulerPainter = function RulerPainter(canvas) {
    * @private
    */
   this.maxGranularity_ = 0;
+
+  /**
+   * Units to display labels in.
+   * @type {wtf.db.Unit}
+   * @private
+   */
+  this.units_ = wtf.db.Unit.TIME_MILLISECONDS;
 
   /**
    * Whether to show the hover bar/time.
@@ -141,8 +148,8 @@ wtf.ui.RulerPainter.prototype.repaintInternal = function(ctx, bounds) {
       }
       var x = wtf.math.remap(time, timeLeft, timeRight, 0, width);
       x = Math.round(x) + 0.5;
-      var timeValue = (time / 1000);
-      var timeString = (Math.round(timeValue * g) / g) + 's';
+      var timeValue = Math.round(time * g) / g;
+      var timeString = wtf.db.Unit.format(time, this.units, true);
       ctx.fillText(timeString, bounds.left + x, bounds.top + 11);
     }
 
@@ -153,7 +160,7 @@ wtf.ui.RulerPainter.prototype.repaintInternal = function(ctx, bounds) {
   // Draw the hover time.
   if (this.showHoverTip_ && this.hoverX_) {
     var time = wtf.math.remap(this.hoverX_, 0, width, timeLeft, timeRight);
-    var timeString = wtf.util.formatTime(time);
+    var timeString = wtf.db.Unit.format(time, this.units);
     var timeWidth = ctx.measureText(timeString).width;
     ctx.globalAlpha = 1;
     ctx.fillStyle = '#FFFFFF';

--- a/src/wtf/ui/timepainter.js
+++ b/src/wtf/ui/timepainter.js
@@ -13,6 +13,7 @@
 
 goog.provide('wtf.ui.TimePainter');
 
+goog.require('wtf.db.Unit');
 goog.require('wtf.ui.Painter');
 
 
@@ -39,6 +40,13 @@ wtf.ui.TimePainter = function(canvas) {
    * @protected
    */
   this.timeRight = 0;
+
+  /**
+   * Units to display labels in.
+   * @type {wtf.db.Unit}
+   * @protected
+   */
+  this.units = wtf.db.Unit.TIME_MILLISECONDS;
 };
 goog.inherits(wtf.ui.TimePainter, wtf.ui.Painter);
 
@@ -51,4 +59,13 @@ goog.inherits(wtf.ui.TimePainter, wtf.ui.Painter);
 wtf.ui.TimePainter.prototype.setTimeRange = function(timeLeft, timeRight) {
   this.timeLeft = timeLeft;
   this.timeRight = timeRight;
+};
+
+
+/**
+ * Sets the units the painter draws labels in.
+ * @param {wtf.db.Unit} value Units.
+ */
+wtf.ui.TimePainter.prototype.setUnits = function(value) {
+  this.units = value;
 };


### PR DESCRIPTION
Disabling health information for non-time dbs. All visible formatting
of values goes through wtf.db.Unit.format. Formatting isn't perfect
(we may want to play with different ways of packing the numbers), but it
works.
Work on #299.
