### PR TITLE
Adding an experimental remote control feature.

### DIFF
--- a/BUILD.anvil
+++ b/BUILD.anvil
@@ -112,6 +112,7 @@ closure_js_library(
         'wtf.app.ui.exports',
         'wtf.db.exports',
         'wtf.hud.exports',
+        'wtf.remote.exports',
         'wtf.trace.exports',
     ],
     srcs=[
@@ -175,10 +176,12 @@ WTF_TRACE_WEB_ENTRY_POINTS=[
     'wtf.ext',
     'wtf.trace.exports',
     'wtf.hud.exports',
+    'wtf.remote.exports',
     ]
 
 WTF_TRACE_WEB_JS_FLAGS=[
     '--define=wtf.hud.exports.ENABLE_EXPORTS=true',
+    '--define=wtf.remote.exports.ENABLE_EXPORTS=true',
     '--define=wtf.trace.exports.ENABLE_EXPORTS=true',
     '--output_wrapper="if(!this.wtf){(function(){%output%}).call(this);}"',
     ]

--- a/bin/controller.html
+++ b/bin/controller.html
@@ -1,0 +1,243 @@
+<!doctype html>
+<html>
+  <head>
+    <title>WTF Controller</title>
+    <style>
+      #tracerList {
+        width: 400px;
+        border: 1px solid black;
+        padding: 3px;
+      }
+      .tracerEntry {
+        border: 1px solid black;
+        margin-bottom: 5px;
+        font: 8pt monospace;
+      }
+      .tracerTitle {
+      }
+      .tracerUrl {
+        color: #888888;
+      }
+      .tracerAgent {
+        color: #aaaaaa;
+        margin-top: 5px;
+        margin-bottom: 5px;
+      }
+      .tracerCommands {
+      }
+      .tracerCommand {
+        text-decoration: underline;
+        margin-right: 5px;
+        cursor: pointer;
+        color: blue;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="tracerList">
+    </div>
+
+    <script>
+      // This gets replaced when the server sends the page down.
+      var uri = '%%CONTROL_URI%%';
+
+      var tracers = {};
+      var listEl = document.getElementById('tracerList');
+
+      var Client = function(uri) {
+        this.socket_ = new WebSocket(uri);
+        this.nextReqId_ = 1;
+        this.pendingCallbacks_ = {};
+        this.lastBinaryTarget_ = null;
+
+        var socket = this.socket_;
+        socket.binaryType = 'arraybuffer';
+        socket.onopen = (function() {
+          // Send hello packet.
+          var packet = {
+            'command': 'hello',
+            'client_type': 'controller'
+          };
+          socket.send(JSON.stringify(packet));
+        }).bind(this);
+        socket.onerror = (function(error) {
+          //
+        }).bind(this);
+        socket.onclose = (function(e) {
+          //
+        }).bind(this);
+        socket.onmessage = (function(e) {
+          if (e.data instanceof ArrayBuffer) {
+            this.handleBinaryMessage(e.data);
+          } else {
+            this.handleMessage(JSON.parse(e.data));
+          }
+        }).bind(this);
+      };
+
+      Client.prototype.handleMessage = function(data) {
+        switch (data['command']) {
+          case 'add_trace_client':
+            tracers[data['id']] = new Tracer(this, data);
+            break;
+          case 'remove_trace_client':
+            tracers[data['id']].remove();
+            delete tracers[data['id']];
+            break;
+          case 'response':
+            this.handleCommandResponse(data);
+            break;
+        }
+      };
+
+      Client.prototype.handleBinaryMessage = function(data) {
+        var callbackInfo = this.lastBinaryTarget_;
+        if (!callbackInfo) {
+          return;
+        }
+        callbackInfo.buffers.push(data);
+        callbackInfo.pendingBufferCount--;
+        if (!callbackInfo.pendingBufferCount) {
+          this.lastBinaryTarget_ = null;
+          callbackInfo.callback.call(callbackInfo.scope,
+              callbackInfo.response, callbackInfo.buffers);
+        }
+      };
+
+      Client.prototype.handleCommandResponse = function(data) {
+        var callbackInfo = this.pendingCallbacks_[data['req_id']];
+        if (callbackInfo) {
+          delete this.pendingCallbacks_[data['req_id']];
+
+          // If we are waiting on buffers we delay callback for now.
+          callbackInfo.response = data;
+          callbackInfo.pendingBufferCount = data['buffer_count'];
+          if (callbackInfo.pendingBufferCount) {
+            this.lastBinaryTarget_ = callbackInfo;
+          } else {
+            callbackInfo.callback.call(callbackInfo.scope,
+                callbackInfo.response, callbackInfo.buffers);
+          }
+        }
+      };
+
+      Client.prototype.sendCommand = function(targetId, commandName,
+          opt_callback, opt_scope) {
+        var reqId = this.nextReqId_++;
+        this.socket_.send(JSON.stringify({
+          'command': 'execute',
+          'id': targetId,
+          'name': commandName,
+          'req_id': reqId
+        }));
+        if (opt_callback) {
+          this.pendingCallbacks_[reqId] = {
+            callback: opt_callback,
+            scope: opt_scope,
+            response: null,
+            buffers: [],
+            pendingBufferCount: 0
+          };
+        }
+      };
+
+      Client.prototype.downloadData = function(filename, mimeType, buffers) {
+        // This code comes from wtf.pal.BrowserPlatform#writeBinaryFile.
+
+        var blob = new Blob(buffers, {
+          'type': mimeType || 'application/octet-stream'
+        });
+
+        // IE10+
+        if (window.navigator['msSaveBlob']) {
+          window.navigator['msSaveBlob'](blob, filename);
+          return;
+        }
+
+        // Download file. Wow.
+        var a = document.createElement('a');
+        a['download'] = filename;
+        a.href = window.URL.createObjectURL(blob);
+        var e = document.createEvent('MouseEvents');
+        e.initMouseEvent(
+            'click',
+            true, false, window, 0, 0, 0, 0, 0,
+            false, false, false, false, 0, null);
+        a.dispatchEvent(e);
+      };
+
+
+      var Tracer = function(client, data) {
+        var id = data['id'];
+        var contextInfo = data['context_info'];
+        var commands = data['commands'];
+
+        this.client_ = client;
+        this.id_ = id;
+        this.contextInfo_ = contextInfo;
+
+        this.el_ = document.createElement('div');
+        var el = this.el_;
+        el.className = 'tracerEntry';
+
+        var titleEl = document.createElement('div');
+        titleEl.className = 'tracerTitle';
+        titleEl.innerHTML = id + ': ' +
+            (contextInfo['title'] || '(unknown title)');
+        el.appendChild(titleEl);
+
+        var urlEl = document.createElement('a');
+        urlEl.className = 'tracerUrl';
+        urlEl.innerHTML = contextInfo['uri'] || '(unknown uri)';
+        urlEl.href = contextInfo['uri'];
+        urlEl.target = '_blank';
+        el.appendChild(urlEl);
+
+        var agentEl = document.createElement('div');
+        agentEl.className = 'tracerAgent';
+        agentEl.innerHTML = (contextInfo['userAgent'] ?
+            contextInfo['userAgent']['value'] : null) || '(unknown UA)';
+        el.appendChild(agentEl);
+
+        var commandsEl = document.createElement('div');
+        commandsEl.className = 'tracerCommands';
+        el.appendChild(commandsEl);
+
+        commands.forEach(function(command) {
+          var commandEl = document.createElement('a');
+          commandEl.className = 'tracerCommand';
+          commandEl.innerHTML = command['title'];
+          commandEl.title = command['tooltip'];
+          commandEl.onclick = function(e) {
+            e.preventDefault();
+            client.sendCommand(id, command['name'], function(data, buffers) {
+              // TODO(benvanik): clean this up a bit. Move to another fn.
+              switch (data['name']) {
+                case 'save_snapshot':
+                  if (!buffers.length) {
+                    window.alert('No data to capture');
+                    return;
+                  }
+                  client.downloadData(
+                      data['filename'],
+                      data['mimetype'],
+                      buffers);
+                  break;
+              }
+            });
+          };
+          commandsEl.appendChild(commandEl);
+        });
+
+        listEl.appendChild(el);
+      };
+
+      Tracer.prototype.remove = function() {
+        this.el_.parentNode.removeChild(this.el_);
+      };
+
+
+      var client = new Client(uri);
+    </script>
+  </body>
+</html>

--- a/bin/controller.js
+++ b/bin/controller.js
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+/**
+ * Copyright 2013 Google, Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+/**
+ * @fileoverview Remote controller server.
+ * Provides a server for remotely controlling WTF instrumented pages.
+ *
+ * @author benvanik@google.com (Ben Vanik)
+ */
+
+var fs = require('fs');
+var http = require('http');
+var optimist = require('optimist');
+var os = require('os');
+var path = require('path');
+var querystring = require('querystring');
+var url = require('url');
+var ws = require('ws');
+
+
+var Server = function(argv) {
+  this.argv_ = argv;
+
+  this.nextId_ = 1;
+  this.clientMap_ = {};
+
+  var uri = 'ws://' + os.hostname() + ':' + argv['ws-port'];
+
+  this.httpServer_ = http.createServer();
+  this.httpServer_.listen(Number(argv['http-port']));
+  this.httpServer_.on('request', function(request, response) {
+    // We only have the one HTTP file right now.
+    var filePath = path.join(__dirname, 'controller.html');
+    var content = fs.readFileSync(filePath, 'utf8');
+    content = content.replace('%%CONTROL_URI%%', uri);
+    contentBuffer = new Buffer(content);
+    response.writeHead(200, {
+      'Content-Type': 'text/html',
+      'Content-Length': contentBuffer.length
+    });
+    response.end(contentBuffer);
+  });
+
+  this.wsServer_ = new ws.Server({
+    port: Number(argv['ws-port'])
+  });
+  this.wsServer_.on('connection', (function(socket) {
+    // Setup a periodic ping.
+    var pingIntervalId = setInterval(function() {
+      socket.ping(undefined, undefined, true);
+    }, 1000);
+    socket.on('close', function() {
+      clearInterval(pingIntervalId);
+    });
+
+    // Wait until the hello packet to create the client object.
+    socket.once('message', (function(message) {
+      var packet = JSON.parse(message);
+      if (!packet || packet['command'] != 'hello') {
+        console.log('[WS] Bad hello packet:');
+        console.log(packet);
+        socket.terminate();
+        return;
+      }
+
+      var client = null;
+      switch (packet['client_type']) {
+        case 'controller':
+          client = new ControlClient(this.nextId_++, this, socket, packet);
+          break;
+        case 'tracer':
+          client = new TraceClient(this.nextId_++, this, socket, packet);
+          break;
+        default:
+          console.log('[WS] Bad client type: ' + packet['client_type']);
+          socket.terminate();
+          break;
+      }
+      this.clientMap_[client.id] = client;
+
+      socket.on('error', (function(error) {
+        console.log('[WS] Socket error: ' + error);
+      }).bind(this));
+      socket.on('close', (function(code) {
+        console.log('[WS] Client disconnected: ' + code);
+        delete this.clientMap_[client.id];
+        client.dispose();
+      }).bind(this));
+    }).bind(this));
+  }).bind(this));
+  this.wsServer_.on('error', function(error) {
+    console.log('[WS] Server Error: ' + error);
+  });
+};
+
+Server.prototype.getClient = function(id) {
+  return this.clientMap_[id] || null;
+};
+
+Server.prototype.forEachControlClient = function(callback, opt_scope) {
+  for (var key in this.clientMap_) {
+    var client = this.clientMap_[key];
+    if (client instanceof ControlClient) {
+      callback.call(opt_scope, client);
+    }
+  }
+};
+
+Server.prototype.forEachTraceClient = function(callback, opt_scope) {
+  for (var key in this.clientMap_) {
+    var client = this.clientMap_[key];
+    if (client instanceof TraceClient) {
+      callback.call(opt_scope, client);
+    }
+  }
+};
+
+
+var ControlClient = function(id, server, socket, packet) {
+  this.id = id;
+  this.server = server;
+  this.socket = socket;
+
+  console.log('[Control] New controller connected');
+
+  socket.on('message', (function(message) {
+    var data = JSON.parse(message);
+    switch (data['command']) {
+      case 'execute':
+        var client = server.getClient(data['id']);
+        data['source_id'] = id;
+        client.socket.send(JSON.stringify(data));
+        break;
+    }
+  }).bind(this));
+
+  // Send the controller all currently connected tracers.
+  server.forEachTraceClient(function(client) {
+    socket.send(JSON.stringify(client.serialize()));
+  }, this);
+};
+
+ControlClient.prototype.dispose = function() {
+  this.socket.terminate();
+};
+
+
+var TraceClient = function(id, server, socket, packet) {
+  this.id = id;
+  this.server = server;
+  this.socket = socket;
+  this.contextInfo = packet['context_info'];
+  this.commands = packet['commands'];
+
+  console.log('[Tracer] New tracer connected: ' + this.contextInfo['title']);
+
+  var previousTargetId = -1;
+  socket.on('message', (function(message) {
+    if (message instanceof Buffer ||
+        message instanceof Uint8Array) {
+      // Binary message - just pass along to whoever was last targetted.
+      var client = server.getClient(previousTargetId);
+      if (client) {
+        client.socket.send(message, {
+          binary: true
+        });
+      }
+    } else {
+      var data = JSON.parse(message);
+      switch (data['command']) {
+        case 'response':
+          previousTargetId = data['id'];
+          var client = server.getClient(data['id']);
+          data['source_id'] = id;
+          client.socket.send(JSON.stringify(data));
+          break;
+      }
+    }
+  }).bind(this));
+
+  // Notify all controllers that we are connected.
+  server.forEachControlClient(function(client) {
+    client.socket.send(JSON.stringify(this.serialize()));
+  }, this);
+};
+
+TraceClient.prototype.dispose = function() {
+  this.socket.terminate();
+
+  // Notify all controllers that we are gone.
+  this.server.forEachControlClient(function(client) {
+    client.socket.send(JSON.stringify({
+      'command': 'remove_trace_client',
+      'id': this.id
+    }));
+  }, this);
+};
+
+TraceClient.prototype.serialize = function() {
+  return {
+    'command': 'add_trace_client',
+    'id': this.id,
+    'context_info': this.contextInfo,
+    'commands': this.commands
+  };
+};
+
+
+function main(argv) {
+  var uri = 'ws://' + os.hostname() + ':' + argv['ws-port'];
+
+  console.log('Launching remote control server...');
+  console.log('   http: ' + argv['http-port']);
+  console.log('     ws: ' + argv['ws-port']);
+  console.log('');
+  console.log('Connect pages using:');
+  console.log('  wtf.remote.connect({');
+  console.log('    \'wtf.remote.target\': \'' + uri + '\'');
+  console.log('  });');
+  console.log('');
+
+  var server = new Server(argv);
+
+  console.log('Server ready, use ctrl-c to exit...');
+  console.log('');
+};
+
+
+main(optimist
+    .usage('Remote control server.\nUsage: $0')
+    .options('p', {
+      alias: 'http-port',
+      type: 'string',
+      default: 8083,
+      desc: 'HTTP control page listen port.'
+    })
+    .options('P', {
+      alias: 'ws-port',
+      type: 'string',
+      default: 8084,
+      desc: 'WebSocket listen port.'
+    })
+    .check(function(argv) {
+      if (argv['help']) {
+        throw '';
+      }
+      return true;
+    })
+    .argv);

--- a/docs/options.md
+++ b/docs/options.md
@@ -142,6 +142,19 @@ The mode used for communicating with the visualizer application. May be one of:
 opened in a new window.
 * `remote`: If set, `wtf.hud.app.endpoint` is a `host:port` of a target HTTP server that will listen for POSTs.
 
+## Remote Control
+
+A page can be connected to a remote server for control via the
+`wtf.remote.connect` method. This allows for snapshotting of instances running
+inside of VMs or over the network that otherwise cannot run a WTF UI or save
+files (such as iOS/Android).
+
+### wtf.remote.target
+
+The target URI to connect to. This must be set. The wtf-controller server will
+list its URL on startup and that value should be used.
+Example: `ws://localhost:8084`
+
 ## App
 
 App options are only used by the app UI. They can be specified to the

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
 
   "dependencies": {
     "falafel": "0.1.4",
-    "optimist": "0.3.5"
+    "optimist": "0.3.5",
+    "ws": "0.4.25"
   },
   "devDependencies": {
     "mocha": "1.4.2",
@@ -54,10 +55,11 @@
 
   "main": "./build-out/wtf_node_js_compiled",
   "bin": {
-    "wtf-trace": "./bin/trace-runner.js",
+    "wtf-controller": "./bin/controller.js",
     "wtf-diff": "./bin/diff.js",
     "wtf-dump": "./bin/dump.js",
     "wtf-instrument": "./bin/instrument.js",
-    "wtf-query": "./bin/query.js"
+    "wtf-query": "./bin/query.js",
+    "wtf-trace": "./bin/trace-runner.js"
   }
 }

--- a/src/wtf/remote/client.js
+++ b/src/wtf/remote/client.js
@@ -1,0 +1,252 @@
+/**
+ * Copyright 2013 Google, Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+/**
+ * @fileoverview Remote control client.
+ *
+ * @author benvanik@google.com (Ben Vanik)
+ */
+
+goog.provide('wtf.remote.Client');
+
+goog.require('goog.Disposable');
+goog.require('goog.asserts');
+goog.require('wtf.data.ContextInfo');
+goog.require('wtf.trace');
+goog.require('wtf.trace.ISessionListener');
+
+
+
+/**
+ * Remote control client.
+ * This connects to an remote server to control tracing.
+ *
+ * @param {!wtf.trace.TraceManager} traceManager Prepared trace manager.
+ * @param {!wtf.util.Options} options Options.
+ * @constructor
+ * @extends {goog.Disposable}
+ * @implements {wtf.trace.ISessionListener}
+ */
+wtf.remote.Client = function(traceManager, options) {
+  goog.base(this);
+
+  /**
+   * Trace manager.
+   * @type {!wtf.trace.TraceManager}
+   * @private
+   */
+  this.traceManager_ = traceManager;
+
+  /**
+   * Options.
+   * @type {!wtf.util.Options}
+   * @private
+   */
+  this.options_ = options;
+
+  /**
+   * Web socket, if connecting or connected.
+   * @type {WebSocket}
+   * @private
+   */
+  this.socket_ = null;
+
+  /**
+   * HUD buttons to be sent to the server.
+   * @type {!Array.<!Object>}
+   * @private
+   */
+  this.providerButtons_ = [];
+
+  // Run through providers and get any buttons/etc we need.
+  // We send these over the wire and handle the RPCs.
+  var providers = traceManager.getProviders();
+  for (var n = 0; n < providers.length; n++) {
+    var provider = providers[n];
+    var buttons = provider.getHudButtons();
+    for (var m = 0; m < buttons.length; m++) {
+      this.providerButtons_.push(buttons[m]);
+    }
+  }
+
+  // TODO(benvanik): add DOM status box
+
+  // Start connecting.
+  var uri = options.getOptionalString('wtf.remote.target');
+  goog.asserts.assert(uri);
+  if (!uri) {
+    throw new Error('wtf.remote.target must be specified');
+  }
+  this.connect_(uri);
+};
+goog.inherits(wtf.remote.Client, goog.Disposable);
+
+
+/**
+ * @override
+ */
+wtf.remote.Client.prototype.disposeInternal = function() {
+  // TODO(benvanik): remove DOM status box
+
+  // Close socket.
+  this.disconnect_();
+
+  goog.base(this, 'disposeInternal');
+};
+
+
+/**
+ * Starts connecting to a remote host.
+ * @param {string} uri Websocket URI.
+ * @private
+ */
+wtf.remote.Client.prototype.connect_ = function(uri) {
+  goog.asserts.assert(!this.socket_);
+
+  // Create the socket.
+  // TODO(benvanik): create raw once there is a WebSocketProvider.
+  var socket = this.socket_ = new WebSocket(uri);
+  socket.binaryType = 'arraybuffer';
+
+  // We avoid using EventHandler so that we can be sure we aren't instrumented.
+  var self = this;
+
+  socket.onopen = wtf.trace.ignoreListener(function() {
+    // Grab context info.
+    var contextInfoJson = wtf.data.ContextInfo.detect().serialize();
+
+    // Setup commands list.
+    var commandsJson = [
+      {
+        'name': 'clear_snapshot',
+        'title': 'Clear Snapshot',
+        'tooltip': 'Reset snapshot data.'
+      },
+      {
+        'name': 'save_snapshot',
+        'title': 'Save Snapshot',
+        'tooltip': 'Save snapshot data to a file.'
+      }
+    ];
+    // TODO(benvanik): add provider buttons.
+    //this.providerButtons_
+
+    // Send over a hello packet to let the server know who we are and what
+    // we support.
+    var packet = {
+      'command': 'hello',
+      'client_type': 'tracer',
+      'context_info': contextInfoJson,
+      'commands': commandsJson
+    };
+    socket.send(goog.global.JSON.stringify(packet));
+  });
+
+  socket.onerror = wtf.trace.ignoreListener(function(error) {
+    goog.global.console.log('remote socket error', error);
+  });
+
+  socket.onclose = wtf.trace.ignoreListener(function(e) {
+    goog.dispose(self);
+  });
+
+  socket.onmessage = wtf.trace.ignoreListener(function(e) {
+    var data = /** @type {Object} */ (goog.global.JSON.parse(e.data));
+    if (!data) {
+      return;
+    }
+    switch (data['command']) {
+      case 'execute':
+        self.executeCommand_(data);
+        break;
+    }
+  });
+};
+
+
+/**
+ * Disconnects and cleans up the current socket, if any.
+ * @private
+ */
+wtf.remote.Client.prototype.disconnect_ = function() {
+  if (!this.socket_) {
+    return;
+  }
+  var socket = this.socket_;
+  this.socket_ = null;
+
+  socket.close();
+
+  socket.onopen = null;
+  socket.onerror = null;
+  socket.onclose = null;
+  socket.onmessage = null;
+};
+
+
+/**
+ * Executes a command from a remote controller.
+ * @param {!Object} data JSON parsed command object.
+ * @private
+ */
+wtf.remote.Client.prototype.executeCommand_ = function(data) {
+  var response = {
+    'command': 'response',
+    'id': data['source_id'],
+    'req_id': data['req_id'],
+    'name': data['name']
+  };
+  var responseBuffers = [];
+
+  switch (data['name']) {
+    case 'clear_snapshot':
+      wtf.trace.reset();
+      break;
+    case 'save_snapshot':
+      // TODO(benvanik): use snapshotAll (or some future API).
+      wtf.trace.snapshot(responseBuffers);
+      response['filename'] = wtf.trace.getTraceFilename();
+      response['mimeType'] = 'application/x-extension-wtf-trace';
+      break;
+    default:
+      // Not a built-in - check provider buttons.
+      // TODO(benvanik): provider buttons.
+      break;
+  }
+
+  // Send the JSON response first.
+  response['buffer_count'] = responseBuffers.length;
+  this.socket_.send(goog.global.JSON.stringify(response));
+
+  // If there are any buffers, send each in its own packet.
+  // We do this so that we avoid JSONifying the buffer data.
+  for (var n = 0; n < responseBuffers.length; n++) {
+    this.socket_.send(responseBuffers[n].buffer);
+  }
+};
+
+
+/**
+ * @override
+ */
+wtf.remote.Client.prototype.sessionStarted = function(session) {
+  //
+};
+
+
+/**
+ * @override
+ */
+wtf.remote.Client.prototype.sessionStopped = function(session) {
+  //
+};
+
+
+/**
+ * @override
+ */
+wtf.remote.Client.prototype.requestSnapshots = goog.nullFunction;

--- a/src/wtf/remote/exports.js
+++ b/src/wtf/remote/exports.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2013 Google, Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+/**
+ * @fileoverview Remote API exports.
+ * Exports the remote control utilities to external code.
+ *
+ * @author benvanik@google.com (Ben Vanik)
+ */
+
+goog.provide('wtf.remote.exports');
+
+goog.require('wtf.remote');
+
+
+/**
+ * @define {boolean} Whether to enable exporting of the wtf.remote
+ *     types and namespace.
+ *
+ * This should only be enabled in builds of the standalone library. If you're
+ * including this code with it enabled in Closurized javascript then you'll
+ * prevent renaming.
+ */
+wtf.remote.exports.ENABLE_EXPORTS = false;
+
+
+if (wtf.remote.exports.ENABLE_EXPORTS) {
+  // wtf.remote controls
+  goog.exportSymbol(
+      'wtf.remote.connect',
+      wtf.remote.connect);
+  goog.exportSymbol(
+      'wtf.remote.disconnect',
+      wtf.remote.disconnect);
+  goog.exportSymbol(
+      'wtf.remote.isConnected',
+      wtf.remote.isConnected);
+}

--- a/src/wtf/remote/remote.js
+++ b/src/wtf/remote/remote.js
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2013 Google, Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+/**
+ * @fileoverview Remote connection utilities.
+ *
+ * @author benvanik@google.com (Ben Vanik)
+ */
+
+goog.provide('wtf.remote');
+
+goog.require('wtf.remote.Client');
+goog.require('wtf.trace');
+
+
+/**
+ * Current client.
+ * Initialized by {@see wtf.remote#connect}.
+ * @type {wtf.remote.Client}
+ * @private
+ */
+wtf.remote.client_ = null;
+
+
+/**
+ * Connects this script to the target URI for remote control.
+ * The current tracing session will be used if it exists.
+ *
+ * This will call {@see wtf.trace#prepare} if it has not already been called.
+ *
+ * @param {Object=} opt_options Options overrides.
+ */
+wtf.remote.connect = function(opt_options) {
+  // Call prepare just in case.
+  wtf.trace.prepare(opt_options);
+  var traceManager = wtf.trace.getTraceManager();
+
+  // Disconect any previous client.
+  wtf.remote.disconnect();
+
+  // Get combined options.
+  var options = traceManager.getOptions(opt_options);
+
+  // Start the connection.
+  wtf.remote.client_ = new wtf.remote.Client(traceManager, options);
+};
+
+
+/**
+ * Disconnects from the remote target.
+ */
+wtf.remote.disconnect = function() {
+  if (!wtf.remote.client_) {
+    return;
+  }
+
+  // Dispose it - if it's currently connecting/connected it'll all be cleaned
+  // up correctly.
+  goog.dispose(wtf.remote.client_);
+  wtf.remote.client_ = null;
+};
+
+
+/**
+ * Whether this script is connected.
+ * This will be true after a call to {@see wtf.remote#connect} even if the
+ * connection is not yet established.
+ * @return {boolean} True if this script is connected to a remote host.
+ */
+wtf.remote.isConnected = function() {
+  return !!wtf.remote.client_;
+};

--- a/src/wtf/trace/trace.js
+++ b/src/wtf/trace/trace.js
@@ -92,11 +92,12 @@ wtf.trace.addSessionListener = function(listener) {
 
 /**
  * Gets a filename to use for a trace file.
- * @param {string} targetValue {@code wtf.trace.target} value.
+ * @param {string=} opt_targetValue {@code wtf.trace.target} value.
  * @return {string} Filename, minus the file:// prefix.
- * @private
  */
-wtf.trace.getTraceFilename_ = function(targetValue) {
+wtf.trace.getTraceFilename = function(opt_targetValue) {
+  var targetValue = opt_targetValue || '';
+
   // If the input looks like a full filename ('file://foo.bar') then use that.
   // Otherwise treat it as a prefix.
   if (goog.string.startsWith(targetValue, 'file://') &&
@@ -177,7 +178,7 @@ wtf.trace.createStream_ = function(options, opt_targetValue) {
       }
     } else if (goog.string.startsWith(targetUrl, 'file://')) {
       // File target.
-      var targetFilename = wtf.trace.getTraceFilename_(targetUrl);
+      var targetFilename = wtf.trace.getTraceFilename(targetUrl);
       return new wtf.io.LocalFileWriteStream(targetFilename);
     }
   } else if (goog.isArray(targetValue)) {

--- a/test/test-remote.html
+++ b/test/test-remote.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>WTF Test (remote)</title>
+  <script src="../wtf_trace_web_js_compiled.js"></script>
+  <!--<script>window.CLOSURE_NO_DEPS = true;</script>
+  <script src="../third_party/closure-library/closure/goog/base.js"></script>
+  <script src="../wtf_js-deps.js"></script>-->
+  <style>
+  </style>
+</head>
+<body>
+  <!--<script>
+    goog.require('wtf.trace.exports');
+    goog.require('wtf.remote.exports');
+  </script>-->
+  <script>
+    var target = window.location.search.substring(1);
+    if (!target.length) {
+      target = 'ws://localhost:8084';
+    }
+    var options = {
+      'wtf.remote.target': target
+    };
+    wtf.remote.connect(options);
+    wtf.trace.start();
+  </script>
+
+  <br/>
+  <br/>
+  <br/>
+  <a id="someLink" href="">Click!</a>
+
+  <script>
+    window.onload = function() {
+      var customAppend = wtf.trace.events.createInstance(
+          'myCustomAppend(uint32 a, uint32 b)',
+          wtf.data.EventFlag.APPEND_SCOPE_DATA);
+      var someLink = document.getElementById('someLink');
+      someLink.onclick = function(e) {
+        e.preventDefault();
+
+        // Enter scope
+        var scope = wtf.trace.enterScope('onclick');
+
+        // Start flow...
+        var flow = wtf.trace.branchFlow('click');
+        window.setTimeout(function() {
+          // Enter scope, resume flow
+          var scope = wtf.trace.enterScope('setTimeout callback');
+          wtf.trace.extendFlow(flow, 'timeout');
+
+          wtf.trace.appendScopeData('number', -1);
+          wtf.trace.appendScopeData('string', 'hello');
+          wtf.trace.appendScopeData('array', [1, 2, 3]);
+          wtf.trace.appendScopeData('obj', {
+            a: 1,
+            b: 2
+          });
+          wtf.trace.appendScopeData('complex', {
+            a: [1, 2, 3],
+            d: {
+              b: [4, 5, 6]
+            }
+          });
+          customAppend(123, 456);
+
+          console.log('hi');
+
+          wtf.trace.terminateFlow(flow);
+          wtf.trace.leaveScope(scope);
+        }, 0);
+
+        wtf.trace.leaveScope(scope);
+      };
+    };
+  </script>
+</body>
+</html>


### PR DESCRIPTION
This allows pages using wtf.remote.connect() to slave themselves to a
controller that can clear or capture snapshots. This enables getting
snapshots from remote devices or browsers that cannot save files themselves
(such as Android/iOS/etc) and makes other browsers easier to work with
(CROS). Could use more features and such, but it seems to work.

Work on #313.
