### PR TITLE
Adding simple scrolling to the tracks panel.

### DIFF
--- a/src/wtf/app/ui/tracks/trackspanel.js
+++ b/src/wtf/app/ui/tracks/trackspanel.js
@@ -137,6 +137,7 @@ wtf.app.ui.tracks.TracksPanel = function(documentView) {
 
   var paintContext = new wtf.ui.Painter(this.trackCanvas_);
   this.setPaintContext(paintContext);
+  this.setScrollablePaintContext(true);
 
   // Clicking on non-handled space will clear the filter.
   var commandManager = wtf.events.getCommandManager();

--- a/src/wtf/app/ui/tracks/trackspanel.soy
+++ b/src/wtf/app/ui/tracks/trackspanel.soy
@@ -22,7 +22,7 @@
     <div class="{css infoControl}"></div>
     <div class="{css canvasOuter}">
       <canvas class="{css tracksCanvas}"></canvas>
-      <div class="{css kScrollShadowBottom}"></div>
+      <!--<div class="{css kScrollShadowBottom}"></div>-->
     </div>
   </div>
 {/template}


### PR DESCRIPTION
This is not a robust implementation and doesn't scale well, but at least
allows for scrolling where it wasn't possible before.

In the future it'd be nice to support fixing the ruler onto the screen,
clipping the viewport to the scrolled region, etc. Software scrolling
(as opposed to browser) is required for this. The table view needs this
anyway so that feature may come at the same time.

Fixes #320.
