### PR TITLE
Fixing the chrome debugger.

### DIFF
--- a/injector/wtf-injector-chrome/injectedtab.js
+++ b/injector/wtf-injector-chrome/injectedtab.js
@@ -103,11 +103,13 @@ var InjectedTab = function(extension, tab, pageOptions, port) {
   if (this.debugger_) {
     this.debuggerTransmitId_ = window.setInterval((function() {
       var records = this.debugger_.getRecords();
-      this.port_.postMessage(JSON.stringify({
-        'command': 'debugger_data',
-        'records': records
-      }));
-      this.debugger_.clearRecords();
+      if (records.length) {
+        this.port_.postMessage(JSON.stringify({
+          'command': 'debugger_data',
+          'records': records
+        }));
+        this.debugger_.clearRecords();
+      }
     }).bind(this), 1000);
   }
 };


### PR DESCRIPTION
The timeline data has changed in the latest version.
This fixes issues with duplicate GC events, the broken ParseHTML event,
adds the MarkDOMContent event, and fixes the enable state toggle.

Fixes #319.
