### PR TITLE
Initial work on getting rich replay events into traces.

### DIFF
--- a/src/wtf/data/webidl.js
+++ b/src/wtf/data/webidl.js
@@ -1,0 +1,380 @@
+/**
+ * Copyright 2013 Google, Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+/**
+ * @fileoverview DOM IDL-like data used for event generation/etc.
+ *
+ * The contents of this file were created by hand by looking at the Chrome IDL
+ * files and cross-referencing them with the W3C specs for those types.
+ * Unfortunately, the IDL files do not describe the types of the events that an
+ * EventTarget emits, so there's no nice automated way to do this.
+ *
+ * @author benvanik@google.com (Ben Vanik)
+ */
+
+goog.provide('wtf.data.webidl');
+
+goog.require('goog.asserts');
+
+
+/**
+ * Event types structures.
+ * @type {!Object.<!Object>}
+ * @const
+ */
+wtf.data.webidl.EVENT_TYPES = {
+  // https://chromium.googlesource.com/chromium/blink/+/master/Source/core/dom/Event.idl
+  'Event': {
+    attributes: {
+      'target': 'dompath',
+      'currentTarget': 'dompath',
+      'timeStamp': 'uint32'
+
+      // clipboardData
+    }
+  },
+
+  // https://chromium.googlesource.com/chromium/blink/+/master/Source/core/dom/ErrorEvent.idl
+  'ErrorEvent': {
+    inherits: 'Event',
+    attributes: {
+      'message': 'utf8',
+      'filename': 'utf8',
+      'lineno': 'uint32'
+    }
+  },
+
+  // https://chromium.googlesource.com/chromium/blink/+/master/Source/core/dom/ProgressEvent.idl
+  'ProgressEvent': {
+    inherits: 'Event',
+    attributes: {
+      'lengthComputable': 'bool',
+      // TODO(benvanik): uint64
+      'loaded': 'uint32',
+      'total': 'uint32'
+    }
+  },
+
+  // https://chromium.googlesource.com/chromium/blink/+/master/Source/core/dom/UIEvent.idl
+  'UIEvent': {
+    inherits: 'Event',
+    attributes: {
+      'keyCode': 'int32',
+      'charCode': 'int32',
+      'layerX': 'int32',
+      'layerY': 'int32',
+      'pageX': 'int32',
+      'pageY': 'int32',
+      'which': 'int32'
+    }
+  },
+
+  // https://chromium.googlesource.com/chromium/blink/+/master/Source/core/dom/FocusEvent.idl
+  'FocusEvent': {
+    inherits: 'UIEvent',
+    attributes: {
+      'relatedTarget': 'dompath'
+    }
+  },
+
+  // https://chromium.googlesource.com/chromium/blink/+/master/Source/core/dom/KeyboardEvent.idl
+  'KeyboardEvent': {
+    inherits: 'KeyboardEvent',
+    attributes: {
+      'keyIdentifier': 'utf8',
+      'keyLocation': 'uint32',
+      'ctrlKey': 'bool',
+      'shiftKey': 'bool',
+      'altKey': 'bool',
+      'metaKey': 'bool',
+      'altGraphKey': 'bool'
+    }
+  },
+
+  // https://chromium.googlesource.com/chromium/blink/+/master/Source/core/dom/MouseEvent.idl
+  'MouseEvent': {
+    inherits: 'UIEvent',
+    attributes: {
+      'screenX': 'int32',
+      'screenY': 'int32',
+      'clientX': 'int32',
+      'clientY': 'int32',
+      'ctrlKey': 'bool',
+      'shiftKey': 'bool',
+      'altKey': 'bool',
+      'metaKey': 'bool',
+      'button': 'uint16',
+      'relatedTarget': 'dompath',
+      'webkitMovementX': 'int32',
+      'webkitMovementY': 'int32',
+
+      'offsetX': 'int32',
+      'offsetY': 'int32',
+      'x': 'int32',
+      'y': 'int32'
+      // fromElement, toElement
+      // dataTransfer
+    }
+  },
+
+  // https://chromium.googlesource.com/chromium/blink/+/master/Source/core/dom/WheelEvent.idl
+  'WheelEvent': {
+    inherits: 'MouseEvent',
+    attributes: {
+      'wheelDeltaX': 'int32',
+      'wheelDeltaY': 'int32',
+      'deltaMode': 'uint32',
+      'wheelDelta': 'int32',
+
+      'webkitDirectionInvertedFromDevice': 'bool'
+    }
+  },
+
+  // https://chromium.googlesource.com/chromium/blink/+/master/Source/core/xml/XMLHttpRequestProgressEvent.idl
+  'XMLHttpRequestProgressEvent': {
+    inherits: 'ProgressEvent',
+    attributes: {
+      // TODO(benvanik): uint64
+      'position': 'uint32',
+      'totalSize': 'uint32'
+    }
+  }
+};
+
+
+/**
+ * Object structures.
+ * @type {!Object.<!Object>}
+ * @const
+ */
+wtf.data.webidl.OBJECTS = {
+  // https://chromium.googlesource.com/chromium/blink/+/master/Source/core/dom/Element.idl
+  'Element': {
+    events: {
+      'abort': null,
+      'blur': 'FocusEvent',
+      'change': null,
+      'click': 'MouseEvent',
+      'contextmenu': null,
+      'dblclick': 'MouseEvent',
+      'drag': null,
+      'dragend': null,
+      'dragenter': null,
+      'dragleave': null,
+      'dragover': null,
+      'dragstart': null,
+      'drop': null,
+      'error': 'ErrorEvent',
+      'focus': 'FocusEvent',
+      'input': null,
+      'invalid': null,
+      'keydown': 'KeyboardEvent',
+      'keypress': 'KeyboardEvent',
+      'keyup': 'KeyboardEvent',
+      'load': null,
+      'mousedown': 'MouseEvent',
+      'mousemove': 'MouseEvent',
+      'mouseout': 'MouseEvent',
+      'mouseover': 'MouseEvent',
+      'mouseup': 'MouseEvent',
+      'mousewheel': 'WheelEvent',
+      'readystatechange': null,
+      'scroll': null,
+      'select': null,
+      'submit': null,
+
+      'animationstart': null,
+      'animationend': null,
+      'animationiteration': null,
+      'transitionend': null,
+
+      'selectstart': null,
+      'touchstart': null,
+      'touchmove': null,
+      'touchend': null,
+      'touchcancel': null,
+      'webkitfullscreenchange': null,
+      'webkitfullscreenerror': null
+    }
+  },
+
+  // https://chromium.googlesource.com/chromium/blink/+/master/Source/core/page/DOMWindow.idl
+  'Window': {
+    // Not really, but it does get its events.
+    inherits: 'Element',
+    events: {
+      'beforeunload': null,
+      'change': null,
+      'hashchange': null,
+      'message': null,
+      'offline': null,
+      'online': null,
+      'pagehide': null,
+      'pageshow': null,
+      'popstate': null,
+      'resize': null,
+      'unload': null
+    }
+  },
+
+  // https://chromium.googlesource.com/chromium/blink/+/master/Source/core/dom/Document.idl
+  'Document': {
+    // Not really, but it does get its events.
+    inherits: 'Element',
+    events: {
+      'webkitpointerlockchange': null,
+      'webkitpointerlockerror': null
+    }
+  },
+
+  // https://chromium.googlesource.com/chromium/blink/+/master/Source/core/html/HTMLElement.idl
+  'HTMLElement': {
+    inherits: 'Element'
+  },
+
+  // https://chromium.googlesource.com/chromium/blink/+/master/Source/core/html/HTMLAnchorElement.idl
+  'HTMLAnchorElement': {
+    tagName: 'a',
+    inherits: 'HTMLElement'
+  },
+
+  // https://chromium.googlesource.com/chromium/blink/+/master/Source/core/html/HTMLCanvasElement.idl
+  'HTMLCanvasElement': {
+    tagName: 'canvas',
+    inherits: 'HTMLElement'
+  },
+
+  // https://chromium.googlesource.com/chromium/blink/+/master/Source/core/html/HTMLDivElement.idl
+  'HTMLDivElement': {
+    tagName: 'div',
+    inherits: 'HTMLElement'
+  },
+
+  // https://chromium.googlesource.com/chromium/blink/+/master/Source/core/xml/XMLHttpRequest.idl
+  'XMLHttpRequest': {
+    events: {
+      'abort': 'XMLHttpRequestProgressEvent',
+      'error': 'XMLHttpRequestProgressEvent',
+      'load': 'XMLHttpRequestProgressEvent',
+      'loadend': 'XMLHttpRequestProgressEvent',
+      'loadstart': 'XMLHttpRequestProgressEvent',
+      'progress': 'XMLHttpRequestProgressEvent',
+      'timeout': 'XMLHttpRequestProgressEvent',
+      'readystatechange': 'XMLHttpRequestProgressEvent'
+    }
+  }
+};
+
+
+/**
+ * Gets a combined list of events and types for the given object.
+ * @param {string} objectName Object name, as a key into {@code OBJECTS}.
+ * @param {Array.<string>=} opt_extraNames Extra event names that should be
+ *     included if they are not in the IDL. They will default to the Event type.
+ * @return {!Object.<!Object>} All events mapped by name to their type object.
+ */
+wtf.data.webidl.getAllEvents = function(objectName, opt_extraNames) {
+  var defaultEventType = wtf.data.webidl.EVENT_TYPES['Event'];
+  var result = {};
+
+  var targetName = objectName;
+  while (true) {
+    var obj = wtf.data.webidl.OBJECTS[targetName];
+    if (!obj) {
+      break;
+    }
+    targetName = obj.inherits;
+
+    for (var key in obj.events) {
+      var eventTypeName = obj.events[key];
+      var eventType = wtf.data.webidl.EVENT_TYPES[eventTypeName];
+      result[key] = eventType || defaultEventType;
+    }
+  }
+
+  if (opt_extraNames) {
+    for (var n = 0; n < opt_extraNames.length; n++) {
+      var eventName = opt_extraNames[n];
+      if (!result[eventName]) {
+        result[eventName] = defaultEventType;
+      }
+    }
+  }
+
+  return result;
+};
+
+
+/**
+ * Gets a list of all attributes for the given event type, in order.
+ * @param {!Object} eventType Event type info from {@code EVENT_TYPES}.
+ * @return {!Array.<{name: string, type: string}>} A list of name/type infos.
+ */
+wtf.data.webidl.getEventAttributes = function(eventType) {
+  // Grab all of the inherited event types.
+  // This way we can write the attributes in order.
+  // Note that this list is reversed, and we should walk it backward.
+  var allEventTypes = [eventType];
+  var parentType = eventType;
+  while (parentType.inherits) {
+    parentType = wtf.data.webidl.EVENT_TYPES[parentType.inherits];
+    goog.asserts.assert(parentType);
+    allEventTypes.push(parentType);
+  }
+
+  var foundNames = {};
+  var result = [];
+  for (var n = allEventTypes.length - 1; n >= 0; n--) {
+    var attributes = allEventTypes[n].attributes;
+    for (var attributeName in attributes) {
+      var attributeType = attributes[attributeName];
+      if (foundNames[attributeName]) {
+        continue;
+      }
+      foundNames[attributeName] = true;
+      result.push({
+        name: attributeName,
+        type: attributeType
+      });
+    }
+  }
+  return result;
+};
+
+
+/**
+ * Gets a full signature for an event type on an object.
+ * @param {string} objectName Object name, like 'HTMLAnchorElement'.
+ * @param {string} eventName Event name, like 'click'.
+ * @param {Object} eventType Event type info from {@code EVENT_TYPES}.
+ * @param {string=} opt_suffix Event name suffix. For example, ':callback'.
+ * @return {string} An event signature like 'HTMLAnchorElement#onclick(...)'.
+ */
+wtf.data.webidl.getEventSignature = function(objectName, eventName, eventType,
+    opt_suffix) {
+  var s = objectName + '#on' + eventName + (opt_suffix ? opt_suffix : '') + '(';
+
+  if (eventType) {
+    // Grab all attributes, in order.
+    var attributes = wtf.data.webidl.getEventAttributes(eventType);
+    for (var n = 0; n < attributes.length; n++) {
+      var attribute = attributes[n];
+      var attributeType = attribute.type;
+      switch (attributeType) {
+        case 'dompath':
+          attributeType = 'ascii';
+          break;
+      }
+      if (n) {
+        s += ', ';
+      }
+      s += attributeType + ' ' + attribute.name;
+    }
+  }
+
+  return s + ')';
+};

--- a/src/wtf/math/mersennetwister.js
+++ b/src/wtf/math/mersennetwister.js
@@ -1,0 +1,209 @@
+/**
+ * Copyright 2013 Google, Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+/**
+ * @fileoverview A Javascript port of Merseene Twister algorithm.
+ * Adapted from https://gist.github.com/banksean/300494
+ * by Sean McCullough (banksean@gmail.com).
+ *
+ * @author benvanik@google.com (Ben Vanik)
+ */
+
+/*
+  A C-program for MT19937, with initialization improved 2002/1/26.
+  Coded by Takuji Nishimura and Makoto Matsumoto.
+
+  Before using, initialize the state by using init_genrand(seed)
+  or init_by_array(init_key, key_length).
+
+  Copyright (C) 1997 - 2002, Makoto Matsumoto and Takuji Nishimura,
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+    1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+    3. The names of its contributors may not be used to endorse or promote
+      products derived from this software without specific prior written
+      permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+  Any feedback is very welcome.
+  http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/emt.html
+  email: m-mat @ math.sci.hiroshima-u.ac.jp (remove space)
+*/
+
+goog.provide('wtf.math.MersenneTwister');
+
+
+
+/**
+ * Mersenne Twister (MT19937) implementation.
+ * @param {number} seed Initial seed value.
+ * @constructor
+ */
+wtf.math.MersenneTwister = function(seed) {
+  /**
+   * The array for the state vector.
+   * @type {!Int32Array}
+   * @private
+   */
+  this.mt_ = new Int32Array(wtf.math.MersenneTwister.N_);
+
+  /**
+   * mti == N + 1 means mt[N] is not initialized.
+   * @type {number}
+   * @private
+   */
+  this.mti_ = wtf.math.MersenneTwister.N_ + 1;
+
+  this.initialize_(seed);
+};
+
+
+/**
+ * @type {number}
+ * @const
+ * @private
+ */
+wtf.math.MersenneTwister.N_ = 624;
+
+
+/**
+ * @type {number}
+ * @const
+ * @private
+ */
+wtf.math.MersenneTwister.M_ = 397;
+
+
+/**
+ * Constant vector a.
+ * mag01[x] = x * MATRIX_A  for x=0,1
+ * @type {!Int32Array}
+ * @const
+ * @private
+ */
+wtf.math.MersenneTwister.MAG01_ = new Int32Array([0, 0x9908b0df]);
+
+
+/**
+ * Most significant w-r bits.
+ * @type {number}
+ * @const
+ * @private
+ */
+wtf.math.MersenneTwister.UPPER_MASK_ = 0x80000000;
+
+
+/**
+ * Least significant r bits.
+ * @type {number}
+ * @const
+ * @private
+ */
+wtf.math.MersenneTwister.LOWER_MASK_ = 0x7FFFFFFF;
+
+
+/**
+ * Initializes mt[N] with a seed.
+ * @param {number} seed Seed value.
+ * @private
+ */
+wtf.math.MersenneTwister.prototype.initialize_ = function(seed) {
+  var mt = this.mt_;
+
+  mt[0] = seed >>> 0;
+  for (this.mti_ = 1; this.mti_ < wtf.math.MersenneTwister.N_; this.mti_++) {
+    var s = mt[this.mti_ - 1] ^ (mt[this.mti_ - 1] >>> 30);
+    mt[this.mti_] =
+        (((((s & 0xffff0000) >>> 16) * 1812433253) << 16) +
+            (s & 0x0000ffff) * 1812433253) + this.mti_;
+    /* See Knuth TAOCP Vol2. 3rd Ed. P.106 for multiplier. */
+    /* In the previous versions, MSBs of the seed affect   */
+    /* only MSBs of the array mt[].                        */
+    /* 2002/01/09 modified by Makoto Matsumoto             */
+    mt[this.mti_] >>>= 0;
+    /* for >32 bit machines */
+  }
+};
+
+
+/**
+ * Generates a random number on [0,0xffffffff]-interval.
+ * @return {number} Random number.
+ */
+wtf.math.MersenneTwister.prototype.randomInt32 = function() {
+  var mt = this.mt_;
+
+  var N = wtf.math.MersenneTwister.N_;
+  var M = wtf.math.MersenneTwister.M_;
+  var MAG01 = wtf.math.MersenneTwister.MAG01_;
+
+  // Generate N words at one time, as needed.
+  if (this.mti_ >= N) {
+    // If init_genrand() has not been called a default initial seed is used.
+    if (this.mti_ == N + 1) {
+      this.initialize_(5489);
+    }
+
+    for (var kk = 0; kk < N - M; kk++) {
+      var y = (mt[kk] & wtf.math.MersenneTwister.UPPER_MASK_) |
+          (mt[kk + 1] & wtf.math.MersenneTwister.LOWER_MASK_);
+      mt[kk] = mt[kk + M] ^ (y >>> 1) ^ MAG01[y & 0x1];
+    }
+    for (; kk < N - 1; kk++) {
+      var y = (mt[kk] & wtf.math.MersenneTwister.UPPER_MASK_) |
+          (mt[kk + 1] & wtf.math.MersenneTwister.LOWER_MASK_);
+      mt[kk] = mt[kk + (M - N)] ^ (y >>> 1) ^ MAG01[y & 0x1];
+    }
+    var y = (mt[N - 1] & wtf.math.MersenneTwister.UPPER_MASK_) |
+        (mt[0] & wtf.math.MersenneTwister.LOWER_MASK_);
+    mt[N - 1] = mt[M - 1] ^ (y >>> 1) ^ MAG01[y & 0x1];
+
+    this.mti_ = 0;
+  }
+
+  var y = mt[this.mti_++];
+
+  // Tempering.
+  y ^= (y >>> 11);
+  y ^= (y << 7) & 0x9d2c5680;
+  y ^= (y << 15) & 0xefc60000;
+  y ^= (y >>> 18);
+
+  return y >>> 0;
+};
+
+
+/**
+ * Generates a random value from [0-1].
+ * @return {number} Random number.
+ */
+wtf.math.MersenneTwister.prototype.random = function() {
+  // Divided by 2^32.
+  return this.randomInt32() * (1 / 4294967296.0);
+};

--- a/src/wtf/trace/flow.js
+++ b/src/wtf/trace/flow.js
@@ -56,19 +56,21 @@ wtf.trace.Flow.INVALID_ID = 0;
 
 
 /**
+ * Next flow ID.
+ * It'd be much better to pick a real ID that won't conflict.
+ * @type {number}
+ * @private
+ */
+wtf.trace.Flow.nextId_ = 1;
+
+
+/**
  * Generates a new semi-unique flow ID.
  * @return {number} Flow ID.
  * @private
  */
 wtf.trace.Flow.generateId_ = function() {
-  var value = 0 | Math.random() * (1 << 31);
-
-  // Ensure generated IDs are never all zeros.
-  if (!value) {
-    value = 1;
-  }
-
-  return value;
+  return wtf.trace.Flow.nextId_++;
 };
 
 

--- a/src/wtf/trace/providers/imageprovider.js
+++ b/src/wtf/trace/providers/imageprovider.js
@@ -13,6 +13,7 @@
 
 goog.provide('wtf.trace.providers.ImageProvider');
 
+goog.require('wtf.data.webidl');
 goog.require('wtf.trace.Provider');
 goog.require('wtf.trace.eventtarget');
 
@@ -70,7 +71,7 @@ wtf.trace.providers.ImageProvider.prototype.getSettingsSectionConfigs =
 wtf.trace.providers.ImageProvider.prototype.injectImage_ = function() {
   var originalImage = goog.global['Image'];
 
-  // TODO(benvanik): inject both Image and HTMLImgElement
+  // TODO(benvanik): inject both Image and HTMLImageElement
 
   // TODO(benvanik): full proxy
   var proto = Image.prototype;
@@ -83,9 +84,13 @@ wtf.trace.providers.ImageProvider.prototype.injectImage_ = function() {
     eventNames = wtf.trace.eventtarget.getEventNames(proto);
   }
 
+  // Get all event types from the IDL store.
+  // This will be a map of event name to the {@code EVENT_TYPES} objects.
+  var eventTypes = wtf.data.webidl.getAllEvents('HTMLImageElement', eventNames);
+
   // Create a descriptor object.
   var descriptor = wtf.trace.eventtarget.createDescriptor(
-      'Image', eventNames);
+      'Image', eventTypes);
 
   // Stash the descriptor. It may be used by the hookDomEvents util.
   wtf.trace.eventtarget.setDescriptor(proto, descriptor);

--- a/src/wtf/trace/providers/providers.js
+++ b/src/wtf/trace/providers/providers.js
@@ -19,6 +19,7 @@ goog.require('wtf.trace.providers.ChromeDebugProvider');
 goog.require('wtf.trace.providers.ConsoleProvider');
 goog.require('wtf.trace.providers.DomProvider');
 goog.require('wtf.trace.providers.ImageProvider');
+goog.require('wtf.trace.providers.ReplayProvider');
 goog.require('wtf.trace.providers.TimingProvider');
 goog.require('wtf.trace.providers.WebGLProvider');
 goog.require('wtf.trace.providers.WebWorkerProvider');
@@ -31,6 +32,13 @@ goog.require('wtf.trace.providers.XhrProvider');
  */
 wtf.trace.providers.setup = function(traceManager) {
   var options = traceManager.getOptions();
+
+  // Replay provider must go first, as it does some really crazy things.
+  if (!wtf.NODE &&
+      options.getBoolean('wtf.trace.replayable', false)) {
+    traceManager.addProvider(
+        new wtf.trace.providers.ReplayProvider(traceManager, options));
+  }
 
   traceManager.addProvider(
       new wtf.trace.providers.ConsoleProvider(options));

--- a/src/wtf/trace/providers/replayprovider.js
+++ b/src/wtf/trace/providers/replayprovider.js
@@ -1,0 +1,301 @@
+/**
+ * Copyright 2013 Google, Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+/**
+ * @fileoverview Replay Javascript event provider.
+ *
+ * @author benvanik@google.com (Ben Vanik)
+ */
+
+goog.provide('wtf.trace.providers.ReplayProvider');
+
+goog.require('goog.asserts');
+goog.require('wtf.data.EventFlag');
+goog.require('wtf.data.webidl');
+goog.require('wtf.math.MersenneTwister');
+goog.require('wtf.trace.ISessionListener');
+goog.require('wtf.trace.Provider');
+goog.require('wtf.trace.events');
+goog.require('wtf.trace.util');
+goog.require('wtf.util');
+goog.require('wtf.util.FunctionBuilder');
+
+
+
+/**
+ * Provides in-depth recording and shims to make runtime code deterministic.
+ * Performance numbers aren't as meaningful with this running as more event
+ * hooks are added.
+ *
+ * @param {!wtf.trace.TraceManager} traceManager Trace manager.
+ * @param {!wtf.util.Options} options Options.
+ * @constructor
+ * @implements {wtf.trace.ISessionListener}
+ * @extends {wtf.trace.Provider}
+ */
+wtf.trace.providers.ReplayProvider = function(traceManager, options) {
+  goog.base(this, options);
+
+  goog.asserts.assert(options.getBoolean('wtf.trace.replayable', false));
+
+  // Error out the feature if not supported.
+  goog.asserts.assert(wtf.util.FunctionBuilder.isSupported());
+  if (!wtf.util.FunctionBuilder.isSupported()) {
+    throw new Error(
+        'Replay not supported; no "new Function()" support available.');
+  }
+
+  /**
+   * The shared function builder object.
+   * @type {!wtf.util.FunctionBuilder}
+   * @private
+   */
+  this.functionBuilder_ = new wtf.util.FunctionBuilder();
+
+  /**
+   * Event used to track the random seed value.
+   * Must be called at the start of every session.
+   * @type {Function}
+   * @private
+   */
+  this.randomSeedEvent_ = wtf.trace.events.createInstance(
+      'wtf.replay#randomSeed(uint32 value)',
+      wtf.trace.providers.ReplayProvider.DEFAULT_FLAGS_);
+
+  this.injectDate_();
+  this.injectEvents_();
+
+  // Listen for sessions so that we can write header events/etc.
+  traceManager.addListener(this);
+};
+goog.inherits(wtf.trace.providers.ReplayProvider, wtf.trace.Provider);
+
+
+/**
+ * Whether to hide events from the UI.
+ * Useful to disable when debugging.
+ * @type {boolean}
+ * @const
+ * @private
+ */
+wtf.trace.providers.ReplayProvider.HIDE_EVENTS_ = false;
+
+
+/**
+ * Default flag bitmask for events.
+ * @type {number}
+ * @const
+ * @private
+ */
+wtf.trace.providers.ReplayProvider.DEFAULT_FLAGS_ =
+    wtf.trace.providers.ReplayProvider.HIDE_EVENTS_ ?
+        wtf.data.EventFlag.INTERNAL : 0;
+
+
+/**
+ * @override
+ */
+wtf.trace.providers.ReplayProvider.prototype.sessionStarted =
+    function(session) {
+  // Re-initialize the RNG with a new seed value and save it off.
+  this.initializeRandom_();
+
+  // TODO(benvanik): attach the global event listeners.
+};
+
+
+/**
+ * @override
+ */
+wtf.trace.providers.ReplayProvider.prototype.sessionStopped =
+    function(session) {
+  // TODO(benvanik): detach the global event listeners.
+};
+
+
+/**
+ * @override
+ */
+wtf.trace.providers.ReplayProvider.prototype.requestSnapshots =
+    goog.nullFunction;
+
+
+/**
+ * Re-initializes the Math.random replacement.
+ * This should be called at the start of each new session.
+ * @private
+ */
+wtf.trace.providers.ReplayProvider.prototype.initializeRandom_ = function() {
+  // Pick a seed value to use for the RNG.
+  // We record this value so that the playback side can seed themselves.
+  // TODO(benvanik): use the raw now()? Would save a single event.
+  var seed = Date.now();
+
+  // Record the used seed.
+  this.randomSeedEvent_(seed);
+
+  // Initialize a deterministic random number generator.
+  var rng = new wtf.math.MersenneTwister(seed);
+
+  // Swap out random with our version.
+  goog.global['Math']['random'] = function deterministicRandom() {
+    return rng.random();
+  };
+};
+
+
+/**
+ * Injects Date functions.
+ * @private
+ */
+wtf.trace.providers.ReplayProvider.prototype.injectDate_ = function() {
+  // We only emit a time advance event when the value queried is not the last
+  // value emitted. This limits us to 1 event/ms, which is acceptable.
+  var lastDateQuery = 0;
+
+  var advanceTimeEvent = wtf.trace.events.createInstance(
+      'wtf.replay#advanceTime(uint32 value)',
+      wtf.trace.providers.ReplayProvider.DEFAULT_FLAGS_);
+
+  var originalDate = goog.global['Date'];
+  var newDate = function() {
+    if (!arguments.length) {
+      return new originalDate(newDate['now']());
+    } else if (arguments.length == 1) {
+      return new originalDate(arguments[0]);
+    } else {
+      return new originalDate(
+          arguments[0], arguments[1], arguments[2], arguments[3],
+          arguments[4], arguments[5], arguments[6]);
+    }
+  };
+  newDate.prototype = originalDate;
+  this.injectFunction(goog.global, 'Date', newDate);
+
+  newDate['parse'] = originalDate['parse'];
+  newDate['UTC'] = originalDate['UTC'];
+  newDate['now'] = function() {
+    var time = originalDate.now();
+    if (time != lastDateQuery) {
+      lastDateQuery = time;
+      advanceTimeEvent(time);
+    }
+    return time;
+  };
+};
+
+
+/**
+ * Injects window/document events to record them.
+ * @private
+ */
+wtf.trace.providers.ReplayProvider.prototype.injectEvents_ = function() {
+  // This will add capture handlers on to the Window and Document objects
+  // that attempt to get all events so that we can dispatchEvent them in
+  // the replay context.
+  // This is different than the {@see wtf.trace.providers.DomProvider} as we
+  // always want full argument data and want to be able to differentiate these
+  // replay events from the normal ones.
+
+  this.injectCaptureEvents_(goog.global['Window'], 'Window', [
+  ]);
+  this.injectCaptureEvents_(goog.global['document'], 'Document', [
+    'click',
+    'mousedown',
+    'mousemove',
+    'mouseup'
+  ]);
+};
+
+
+/**
+ * Injects capturing event listeners for the given events.
+ * @param {!Object} target Event listener that will have events added to it.
+ * @param {string} objectName Object name, like 'Window'.
+ * @param {!Array.<string>} eventNames A list of event names, like 'click'.
+ *     These events will be instrumented for replaying.
+ * @private
+ */
+wtf.trace.providers.ReplayProvider.prototype.injectCaptureEvents_ =
+    function(target, objectName, eventNames) {
+  // Grab all event types, filter by required names.
+  var eventTypes = wtf.data.webidl.getAllEvents(objectName);
+  for (var n = 0; n < eventNames.length; n++) {
+    var eventName = eventNames[n];
+    var eventType = eventTypes[eventName];
+
+    // Generate event listener function.
+    var listener = this.buildListener_(objectName, eventName, eventType);
+
+    // Add capture event.
+    // The hope is that we are the first thing to run, so we are the first to
+    // be added.
+    target.addEventListener(
+        eventName, wtf.trace.util.ignoreListener(listener), true);
+  }
+};
+
+
+// TODO(benvanik): move this into webidl with options for suffix and wtf event
+//     type so that it can be shared with other providers.
+/**
+ * Builds a WTF event and listener function for a given event.
+ * @param {string} objectName Object name, like 'Window'.
+ * @param {string} eventName Event name, like 'click'.
+ * @param {!Object} eventType Event type from {@see wtf.data.webidl}.
+ * @return {!Function} Listener function.
+ * @private
+ */
+wtf.trace.providers.ReplayProvider.prototype.buildListener_ =
+    function(objectName, eventName, eventType) {
+  // Generate the event signature.
+  var signature = wtf.data.webidl.getEventSignature(
+      objectName, eventName, eventType, ':replay');
+
+  // Create instance event. We don't care about duration.
+  var recordEvent = wtf.trace.events.createInstance(
+      signature,
+      wtf.trace.providers.ReplayProvider.DEFAULT_FLAGS_);
+
+  // Create the function that actually captures the event data and event.
+  // This will be passed as a listener to addEventListener.
+  var builder = this.functionBuilder_;
+  builder.begin();
+  builder.addScopeVariable('getElementPath', wtf.util.getElementXPath);
+  builder.addScopeVariable('recordEvent', recordEvent);
+  builder.addArgument('e');
+
+  // TODO(benvanik): de-dupe target/currentTarget/etc now.
+
+  builder.append('  recordEvent(');
+
+  var attributes = wtf.data.webidl.getEventAttributes(eventType);
+  for (var n = 0; n < attributes.length; n++) {
+    var attributeName = attributes[n].name;
+    var attributeType = attributes[n].type;
+
+    var line = '    ';
+    switch (attributeType) {
+      case 'dompath':
+        line += 'getElementPath(e.' + attributeName + ')';
+        break;
+      default:
+        line += 'e.' + attributeName;
+        break;
+    }
+
+    if (n < attributes.length - 1) {
+      line += ', ';
+    }
+
+    builder.append(line);
+  }
+
+  builder.append('    );');
+
+  return builder.end(objectName + '#on' + eventName + ':capture');
+};

--- a/src/wtf/trace/providers/webworkerprovider.js
+++ b/src/wtf/trace/providers/webworkerprovider.js
@@ -20,6 +20,7 @@ goog.require('goog.result');
 goog.require('goog.result.Result');
 goog.require('goog.result.SimpleResult');
 goog.require('goog.string');
+goog.require('wtf.data.webidl');
 goog.require('wtf.trace');
 goog.require('wtf.trace.ISessionListener');
 goog.require('wtf.trace.Provider');
@@ -160,10 +161,14 @@ wtf.trace.providers.WebWorkerProvider.prototype.injectBrowserShim_ =
   var originalWorker = goog.global['Worker'];
   var prefix = 'Worker';
 
-  var descriptor = wtf.trace.eventtarget.createDescriptor('Worker', [
+  // Get all event types from the IDL store.
+  // This will be a map of event name to the {@code EVENT_TYPES} objects.
+  var eventTypes = wtf.data.webidl.getAllEvents('Worker', [
     'error',
     'message'
   ]);
+
+  var descriptor = wtf.trace.eventtarget.createDescriptor('Worker', eventTypes);
 
   // Get WTF URL.
   var wtfUrl = wtf.trace.util.getScriptUrl();
@@ -408,14 +413,18 @@ wtf.trace.providers.WebWorkerProvider.prototype.injectProxyWorker_ =
   var workerId = goog.global['WTF_WORKER_ID'];
   var baseUri = new goog.Uri(goog.global['WTF_WORKER_BASE_URI']);
 
+  // Get all event types from the IDL store.
+  // This will be a map of event name to the {@code EVENT_TYPES} objects.
+  var eventTypes = wtf.data.webidl.getAllEvents('WorkerGlobalScope', [
+    'error',
+    'online',
+    'offline',
+    'message'
+  ]);
+
   // Mixin addEventListener/etc.
   var globalDescriptor = wtf.trace.eventtarget.createDescriptor(
-      'WorkerGlobalScope', [
-        'error',
-        'online',
-        'offline',
-        'message'
-      ]);
+      'WorkerGlobalScope', eventTypes);
   wtf.trace.eventtarget.mixin(globalDescriptor, goog.global);
 
   // Setup on* events.

--- a/src/wtf/trace/providers/xhrprovider.js
+++ b/src/wtf/trace/providers/xhrprovider.js
@@ -13,6 +13,7 @@
 
 goog.provide('wtf.trace.providers.XhrProvider');
 
+goog.require('wtf.data.webidl');
 goog.require('wtf.trace');
 goog.require('wtf.trace.Flow');
 goog.require('wtf.trace.Provider');
@@ -75,17 +76,12 @@ wtf.trace.providers.XhrProvider.prototype.getSettingsSectionConfigs =
 wtf.trace.providers.XhrProvider.prototype.injectXhr_ = function() {
   var originalXhr = goog.global['XMLHttpRequest'];
 
+  // Get all event types from the IDL store.
+  // This will be a map of event name to the {@code EVENT_TYPES} objects.
+  var eventTypes = wtf.data.webidl.getAllEvents('XMLHttpRequest');
+
   var descriptor = wtf.trace.eventtarget.createDescriptor(
-      'XMLHttpRequest', [
-        'loadstart',
-        'progress',
-        'abort',
-        'error',
-        'load',
-        'timeout',
-        'loadend',
-        'readystatechange'
-      ]);
+      'XMLHttpRequest', eventTypes);
 
   /**
    * Proxy XHR.

--- a/src/wtf/util/util.js
+++ b/src/wtf/util/util.js
@@ -207,6 +207,62 @@ wtf.util.convertUint8ArrayToAsciiString = function(value) {
 };
 
 
+/**
+ * Generates an XPath expression that tries to uniquely identify a DOM element.
+ * @param {Element} targetElement DOM element.
+ * @return {?string} XPath string or null if not possible.
+ */
+wtf.util.getElementXPath = function(targetElement) {
+  if (!targetElement) {
+    // No element is null.
+    return null;
+  } else if (targetElement.id) {
+    // Element has an ID - easy.
+    return '//*[@id="' + targetElement.id + '"]';
+  }
+
+  // Slow path - build a full xpath string.
+  var paths = [];
+  for (var el = targetElement;
+      el && el.nodeType == Node.ELEMENT_NODE; el = el.parentNode) {
+    var index = 0;
+    for (var sibling = el.previousSibling; sibling;
+        sibling = sibling.previousSibling) {
+      if (sibling.nodeType == Node.DOCUMENT_TYPE_NODE) {
+        continue;
+      }
+      if (sibling.nodeName == el.nodeName) {
+        index++;
+      }
+    }
+    var tagName = el.nodeName.toLowerCase();
+    var pathIndex = '[' + (index + 1) + ']';
+    paths.splice(0, 0, tagName + pathIndex);
+  }
+  return paths.length ? '/' + paths.join('/') : null;
+};
+
+
+/**
+ * Attempts to find an element int he DOM by XPath.
+ * @param {string?} path XPath query string.
+ * @param {Document=} opt_document Document to query.
+ * @return {Element} Element, if found.
+ */
+wtf.util.findElementByXPath = function(path, opt_document) {
+  if (!path) {
+    return null;
+  }
+  var result = document.evaluate(
+      path,
+      opt_document || goog.global['document'],
+      null,
+      XPathResult.FIRST_ORDERED_NODE_TYPE,
+      null);
+  return result.singleNodeValue;
+};
+
+
 goog.exportSymbol(
     'wtf.util.formatTime',
     wtf.util.formatTime);

--- a/test/test-uncompiled.html
+++ b/test/test-uncompiled.html
@@ -20,7 +20,8 @@
       'wtf.hud.app.endpoint': 'http://localhost:8080/app/maindisplay-debug.html',
       'wtf.trace.target': 'file://test',
       //'wtf.trace.target': 'http://localhost:9024',
-      'wtf.trace.streaming.flushIntervalMs': 100
+      'wtf.trace.streaming.flushIntervalMs': 100,
+      'wtf.trace.replayable': true
     };
     wtf.hud.prepare(options);
     wtf.trace.start(options);


### PR DESCRIPTION
This adds a new WebIDL-esque data type that tracks objects and their
events and types. It's used to start generating the rich event recording
functions required for replay, though it's off (and unimplemented) for
the normal event recording right now due to perf impact. Hopefully this
can be fixed in the future with string tables.

Adding the ReplayProvider that, when enabled, records time queries,
replaces Math.random with a seedable RNG, and listens for a few events.

Making flow IDs deterministic. This is ok for now as they aren't used.

More events and other information will be added in the future.
