### PR TITLE
Made event sequence test aggregate a list of events.

### DIFF
--- a/src/wtf/testing/mocha.js
+++ b/src/wtf/testing/mocha.js
@@ -137,8 +137,10 @@ wtf.testing.mocha.setup_ = function() {
       target.addListener(eventType, goog.partial(handler, eventType));
     }
 
-    var index = 0;
+    var eventsActuallyEmitted = [];
     function handler(eventType) {
+      var index = eventsActuallyEmitted.length;
+      eventsActuallyEmitted.push(eventType);
       if (eventType != eventList[index]) {
         assert.fail('Event ' + eventType + ' called when ' +
             eventList[index] + ' was expected');
@@ -151,8 +153,6 @@ wtf.testing.mocha.setup_ = function() {
 
       var args = Array.prototype.slice.call(arguments, 1);
       callbackList[index].apply(null, args);
-
-      index++;
     };
   };
 };


### PR DESCRIPTION
The test for a sequence of events now aggregates a list of events emitted instead of having a single index. The reason for this change was that previously, each event handler had wrongly stored its own index value, whereas we wanted the count of events emitted to reflect all event types.  Now, all event handlers store a reference to the same list.
