### PR TITLE
Made event table scroll to active row upon resize.

### DIFF
--- a/src/wtf/replay/graphics/ui/eventnavigator.js
+++ b/src/wtf/replay/graphics/ui/eventnavigator.js
@@ -56,6 +56,13 @@ wtf.replay.graphics.ui.EventNavigator = function(
   this.registerDisposable(this.table_);
   this.table_.setSource(this.tableSource_);
 
+  /**
+   * The playback.
+   * @type {!wtf.replay.graphics.Playback}
+   * @private
+   */
+  this.playback_ = playback;
+
   // Listen to changes in step.
   this.listenToStepUpdates_(playback);
 
@@ -81,6 +88,7 @@ wtf.replay.graphics.ui.EventNavigator.prototype.createDom = function(dom) {
  */
 wtf.replay.graphics.ui.EventNavigator.prototype.layout = function() {
   this.table_.layout();
+  this.updateScrolling(this.playback_);
 };
 
 


### PR DESCRIPTION
Previously, when a user resized the event navigator virtual table for graphics replay, the virtual table listing the events for a step would scroll to the top, forcing the user to scroll back down. Now, the table scrolls back to the row marking the current event upon resize.
