### PR TITLE
Allowed the WebGL provider to get attributes data.

### DIFF
--- a/app/scripts/debug-graphicsreplay.js
+++ b/app/scripts/debug-graphicsreplay.js
@@ -17,5 +17,5 @@ debugImportAndExecute([
 ], function() {
   var parentElement = document.getElementById('graphicsReplayStagingArea');
   wtf.replay.graphics.setupStandalone(
-      '../private/traces/vectortown-fun.wtf-trace', parentElement);
+      '../private/traces/zoomInToGasworks.wtf-trace', parentElement);
 });

--- a/src/wtf/replay/graphics/playback.js
+++ b/src/wtf/replay/graphics/playback.js
@@ -1275,7 +1275,7 @@ wtf.replay.graphics.Playback.prototype.realizeEvent_ = function(it) {
       break;
     case 'WebGLRenderingContext#linkProgram':
       // Do all the attribute bindings, then link.
-      var attribMap = args['attribs'];
+      var attribMap = args['attributes'];
       for (var attribName in attribMap) {
         currentContext.bindAttribLocation(
             /** @type {WebGLProgram} */ (objs[args['program']]),


### PR DESCRIPTION
The WebGL provider now collects the active attributes upon linking a program if resources are collected. This enables graphics replay to work across machines.
