### PR TITLE
Let the user specify the trace URL. Fixes #384.

### DIFF
--- a/app/scripts/debug-graphicsreplay.js
+++ b/app/scripts/debug-graphicsreplay.js
@@ -15,7 +15,14 @@
 debugImportAndExecute([
   'wtf.replay.graphics'
 ], function() {
+  // Get the trace URL.
+  var search = window.location.search;
+  if (!search || !search.length || !(search.indexOf('?url=') == 0)) {
+    throw new Error(
+        'No trace URL specified. Specify the trace URL after \'?url=\'.');
+  }
+  var traceUrl = search.substr(5);
+
   var parentElement = document.getElementById('graphicsReplayStagingArea');
-  wtf.replay.graphics.setupStandalone(
-      '../private/traces/zoomInToGasworks.wtf-trace', parentElement);
+  wtf.replay.graphics.setupStandalone(traceUrl, parentElement);
 });

--- a/app/scripts/release-graphicsreplay.js
+++ b/app/scripts/release-graphicsreplay.js
@@ -11,7 +11,13 @@
  * @author chizeng@google.com (Chi Zeng)
  */
 
+// Get the trace URL.
+var search = window.location.search;
+if (!search || !search.length || search.indexOf('?url=') != 0) {
+  throw new Error(
+      'No trace URL specified. Specify the trace URL after \'?url=\'.');
+}
+var traceUrl = search.substr(5);
 
 var parentElement = document.getElementById('graphicsReplayStagingArea');
-wtf.replay.graphics.setupStandalone(
-    '../private/traces/vectortown-fun.wtf-trace', parentElement);
+wtf.replay.graphics.setupStandalone(traceUrl, parentElement);


### PR DESCRIPTION
The user can now specify the trace URL in the GET parameters of the URL of the standalone graphics replay file. Fixes #384. 
