### PR TITLE
Added a previous draw call button.

### DIFF
--- a/src/wtf/replay/graphics/ui/graphicstoolbar.js
+++ b/src/wtf/replay/graphics/ui/graphicstoolbar.js
@@ -77,6 +77,14 @@ wtf.replay.graphics.ui.GraphicsToolbar = function(
       this.getChildElement(goog.getCssName('graphicsReplayForwardButton'));
 
   /**
+   * The previous draw call button.
+   * @type {!Element}
+   * @private
+   */
+  this.previousDrawCallButton_ = this.getChildElement(
+      goog.getCssName('graphicsReplayPreviousDrawCallButton'));
+
+  /**
    * The next draw call button.
    * @type {!Element}
    * @private
@@ -130,6 +138,8 @@ wtf.replay.graphics.ui.GraphicsToolbar.prototype.setInitialButtonStates_ =
   this.toggleButton(goog.getCssName('graphicsReplayResetButton'), true);
   this.toggleButton(goog.getCssName('graphicsReplayPlayButton'), true);
   this.toggleButton(goog.getCssName('graphicsReplayForwardButton'), true);
+  this.toggleButton(
+      goog.getCssName('graphicsReplayPreviousDrawCallButton'), true);
   this.toggleButton(goog.getCssName('graphicsReplayNextDrawCallButton'), true);
 };
 
@@ -157,6 +167,10 @@ wtf.replay.graphics.ui.GraphicsToolbar.prototype.listenToClickEvents_ =
       this.forwardButton_,
       goog.events.EventType.CLICK,
       this.forwardClickHandler_, false, this);
+  eh.listen(
+      this.previousDrawCallButton_,
+      goog.events.EventType.CLICK,
+      this.previousDrawCallClickHandler_, false, this);
   eh.listen(
       this.nextDrawCallButton_,
       goog.events.EventType.CLICK,
@@ -278,6 +292,18 @@ wtf.replay.graphics.ui.GraphicsToolbar.prototype.forwardClickHandler_ =
         'Can\'t seek beyond last step index of ' + lastStepIndex + '.');
   }
   playback.seekStep(currentStepIndex + 1);
+};
+
+
+/**
+ * Handles clicks of the previous draw call button.
+ * @private
+ */
+wtf.replay.graphics.ui.GraphicsToolbar.prototype.previousDrawCallClickHandler_ =
+    function() {
+  this.playback_.seekToPreviousDrawCall();
+  this.emitEvent(
+      wtf.replay.graphics.ui.GraphicsToolbar.EventType.MANUAL_SUB_STEP_SEEK);
 };
 
 

--- a/src/wtf/replay/graphics/ui/graphicstoolbar.less
+++ b/src/wtf/replay/graphics/ui/graphicstoolbar.less
@@ -22,5 +22,7 @@
 
   .graphicsReplayForwardButton {}
 
+  .graphicsReplayPreviousDrawCallButton {}
+
   .graphicsReplayNextDrawCallButton {}
 }

--- a/src/wtf/replay/graphics/ui/graphicstoolbar.soy
+++ b/src/wtf/replay/graphics/ui/graphicstoolbar.soy
@@ -31,6 +31,9 @@
       <a class="{css kButton} {css kMenuButton} {css kDisabled} {css graphicsReplayForwardButton}" title="Forward 1 Step">
         Forward 1 Step
       </a>
+      <a class="{css kButton} {css kMenuButton} {css kDisabled} {css graphicsReplayPreviousDrawCallButton}" title="Previous Draw Call">
+        Previous Draw Call
+      </a>
       <a class="{css kButton} {css kMenuButton} {css kDisabled} {css graphicsReplayNextDrawCallButton}" title="Next Draw Call">
         Next Draw Call
       </a>


### PR DESCRIPTION
Added a button that seeks to the previous draw call within a step. If no draw call precedes the current call (or no call within the current step has run), then clicking on the button just seeks to the start of a step. This button nicely complements the next draw call button.
