### PR TITLE
Made seek to previous draw call stop at step start.

### DIFF
--- a/src/wtf/replay/graphics/playback.js
+++ b/src/wtf/replay/graphics/playback.js
@@ -857,8 +857,9 @@ wtf.replay.graphics.Playback.prototype.seekToPreviousDrawCall = function() {
 
   var it = currentStep.getEventIterator(true);
   var eventJustFinishedIndex = this.subStepId_;
-  if (eventJustFinishedIndex === null || eventJustFinishedIndex == 0) {
-    // No draw call can be before the start of the step or the first step.
+
+  if (eventJustFinishedIndex === null) {
+    // No draw call can be before the start of the step.
     return;
   }
 


### PR DESCRIPTION
Previously, the seek to previous draw call feature stopped at the first step when a step only had 1 event. Now, the previous draw call feature stops at the beginning of the current step - before any event has run.
