### PR TITLE
Got graphics replay to work in Firefox 24.0.

### DIFF
--- a/app/graphicsreplay-debug.html
+++ b/app/graphicsreplay-debug.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset=utf-8>
   <title>WTF Graphics Replay (DEBUG)</title>
   <link rel="stylesheet" href="../wtf_ui_styles_debug.css" type="text/css"/>
   <script src="scripts/debug-prefix.js"></script>

--- a/app/graphicsreplay.html
+++ b/app/graphicsreplay.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset=utf-8>
   <title>WTF Graphics Replay</title>
   <link rel="stylesheet" href="../wtf_ui_styles_release.css" type="text/css"/>
   <script src="../wtf_ui_js_compiled.js"></script>

--- a/src/wtf/replay/graphics/extensionmanager.js
+++ b/src/wtf/replay/graphics/extensionmanager.js
@@ -1,0 +1,116 @@
+/**
+ * Copyright 2013 Google, Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+/**
+ * @fileoverview ExtensionManager. Manages extensions and verifies support for
+ * them.
+ *
+ * @author chizeng@google.com (Chi Zeng)
+ */
+
+goog.provide('wtf.replay.graphics.ExtensionManager');
+
+goog.require('goog.Disposable');
+goog.require('goog.object');
+goog.require('goog.string');
+
+
+
+/**
+ * Verifies if extensions are supported and tries to retrieve other extensions
+ * that perform the same function if not.
+ *
+ * @param {!wtf.replay.graphics.ContextPool} contextPool Pool of contexts.
+ * @constructor
+ * @extends {goog.Disposable}
+ */
+wtf.replay.graphics.ExtensionManager = function(contextPool) {
+  goog.base(this);
+
+  /**
+   * The context pool.
+   * @type {!wtf.replay.graphics.ContextPool}
+   * @private
+   */
+  this.contextPool_ = contextPool;
+
+  /**
+   * The set of supported extensions.
+   * @type {!Object.<boolean>}
+   * @private
+   */
+  this.supportedExtensions_ = this.getSupportedExtensions_();
+};
+goog.inherits(wtf.replay.graphics.ExtensionManager, goog.Disposable);
+
+
+/**
+ * A list of potential extension prefixes.
+ * @const
+ * @type {!Array.<string>}
+ */
+wtf.replay.graphics.ExtensionManager.PREFIXES = ['MOZ_', 'WEBKIT_'];
+
+
+/**
+ * Gets the set of supported extensions.
+ * @return {!Object.<boolean>} The set of supported extensions.
+ * @private
+ */
+wtf.replay.graphics.ExtensionManager.prototype.getSupportedExtensions_ =
+    function() {
+  var webglContext = this.contextPool_.getContext('webgl') ||
+      this.contextPool_.getContext('experimental-webgl');
+  var supportedExtensions =
+      goog.object.createSet(webglContext.getSupportedExtensions());
+  this.contextPool_.releaseContext(webglContext);
+  return supportedExtensions;
+};
+
+
+/**
+ * Gets a related extension name supported by the user agent. Returns the same
+ * extension if the user agent supports it. If no related extension is
+ * supported by the user agent, returns null.
+ * @param {string} extensionName The name of the extension to check.
+ * @return {string?} The name of a related supported extension or null if one
+ *     does not exist.
+ */
+wtf.replay.graphics.ExtensionManager.prototype.getRelatedExtension =
+    function(extensionName) {
+  // If this extension is supported, return the same name back.
+  // This is a common result, so we should optimize for it.
+  if (this.supportedExtensions_[extensionName]) {
+    return extensionName;
+  }
+
+  // Strip off the extension's prefix if there is one.
+  var listOfPrefixes = wtf.replay.graphics.ExtensionManager.PREFIXES;
+  for (var i = 0; i < listOfPrefixes.length; ++i) {
+    if (goog.string.startsWith(extensionName, listOfPrefixes[i])) {
+      // Take off the prefix. Try testing without it.
+      extensionName = extensionName.substring(listOfPrefixes[i].length);
+      if (this.supportedExtensions_[extensionName]) {
+        return extensionName;
+      }
+
+      // If one prefix matched, the other prefixes can't.
+      break;
+    }
+  }
+
+  // Try adding prefixes and testing.
+  for (var i = 0; i < listOfPrefixes.length; ++i) {
+    var prefixedExtensionName = listOfPrefixes[i] + extensionName;
+    if (this.supportedExtensions_[prefixedExtensionName]) {
+      return prefixedExtensionName;
+    }
+  }
+
+  // This extension is not supported, and we can't find a related extension.
+  return null;
+};

--- a/src/wtf/replay/graphics/graphics.js
+++ b/src/wtf/replay/graphics/graphics.js
@@ -34,7 +34,8 @@ wtf.replay.graphics.setupStandalone = function(
   var domHelper = new goog.dom.DomHelper(parentElement.ownerDocument);
 
   var xhr = new XMLHttpRequest();
-  xhr.responseType = 'arraybuffer';
+  xhr.open('GET', traceUrl, true);
+
   xhr.onload = function() {
     if (xhr.status != 200) {
       throw new Error('Failed: ' + xhr.status + ', ' + xhr.statusText);
@@ -54,7 +55,7 @@ wtf.replay.graphics.setupStandalone = function(
     });
   };
 
-  xhr.open('GET', traceUrl, true);
+  xhr.responseType = 'arraybuffer';
   xhr.send();
 };
 


### PR DESCRIPTION
Created an extension manager to check if desired extensions are supported. If an extension is not supported, the manager tries to find a related one that is supported by altering prefixes.
