### PR TITLE
Removed === from graphics replay files.

### DIFF
--- a/src/wtf/replay/graphics/ui/eventnavigator.js
+++ b/src/wtf/replay/graphics/ui/eventnavigator.js
@@ -153,8 +153,7 @@ wtf.replay.graphics.ui.EventNavigator.prototype.unListenToStepUpdates_ =
  */
 wtf.replay.graphics.ui.EventNavigator.prototype.updateScrolling = function(
     playback) {
-  var rowToScrollTo = playback.getSubStepEventId();
-  rowToScrollTo = (rowToScrollTo === null) ? 0 : rowToScrollTo + 1;
+  var rowToScrollTo = playback.getSubStepEventId() + 1;
   this.table_.scrollToRow(
       rowToScrollTo, wtf.ui.VirtualTable.Alignment.MIDDLE);
 };

--- a/src/wtf/replay/graphics/ui/eventnavigatorsource.js
+++ b/src/wtf/replay/graphics/ui/eventnavigatorsource.js
@@ -107,7 +107,7 @@ wtf.replay.graphics.ui.EventNavigatorTableSource.prototype.paintRowRange =
 
     // TODO(benvanik): icons to differentiate event types?
     if (!hideCall) {
-      if (((currentRow === null) && (!n)) || currentRow === n - 1) {
+      if (((currentRow == -1) && (!n)) || currentRow == n - 1) {
         ctx.fillStyle = highlightedColor;
       } else {
         ctx.fillStyle = n % 2 ? color1 : color2;


### PR DESCRIPTION
Removed the triple comparison operator from graphics replay files since the operator makes comparisons brittle. The substep index of a playback (which denotes the current call within the current step) now returns -1 instead of null if no current substep exists.
