### PR TITLE
Let user alter event arguments.

### DIFF
--- a/src/wtf/replay/graphics/playback_test.js
+++ b/src/wtf/replay/graphics/playback_test.js
@@ -32,20 +32,24 @@ wtf.replay.graphics.Playback_test =
       instanceEventTypes: [
         'wtf.timing#frameStart(uint32 number)',
         'wtf.timing#frameEnd(uint32 number)',
-        'someInstanceEvent()'
+        'someInstanceEvent()',
+        'wtf.webgl#createContext(uint32 handle, any attributes)'
       ],
       events: [
         [0, 'someInstanceEvent'],
         [10, 'wtf.timing#frameStart', 100],
+        [15, 'wtf.webgl#createContext', 1, {}],
         [20, 'someInstanceEvent'],
         [30, 'wtf.timing#frameEnd', 100],
         [40, 'someInstanceEvent'],
         [50, 'wtf.timing#frameStart', 200],
         [60, 'someInstanceEvent'],
+        [65, 'wtf.webgl#createContext', 2, {}],
         [70, 'wtf.timing#frameEnd', 200],
         [80, 'someInstanceEvent'],
         [90, 'wtf.timing#frameStart', 300],
         [100, 'someInstanceEvent'],
+        [105, 'wtf.webgl#createContext', 3, {}],
         [110, 'wtf.timing#frameEnd', 300]
       ]});
     frameList = new wtf.db.FrameList(eventList);
@@ -118,6 +122,7 @@ wtf.replay.graphics.Playback_test =
          var exceptionThrown = false;
          try {
            playback.play();
+           assert.isTrue(playback.isPlaying());
            playback.play();
          } catch (exception) {
            exceptionThrown = true;
@@ -147,10 +152,12 @@ wtf.replay.graphics.Playback_test =
       instanceEventTypes: [
         'wtf.timing#frameStart(uint32 number)',
         'wtf.timing#frameEnd(uint32 number)',
-        'someInstanceEvent()'
+        'someInstanceEvent()',
+        'wtf.webgl#createContext(uint32 handle, any attributes)'
       ],
       events: [
-        [0, 'someInstanceEvent'],
+        [0, 'wtf.webgl#createContext', 1, {}],
+        [10, 'someInstanceEvent'],
         [20, 'someInstanceEvent'],
         [40, 'someInstanceEvent'],
         [60, 'someInstanceEvent'],
@@ -164,8 +171,8 @@ wtf.replay.graphics.Playback_test =
        function() {
          var currentStep = playback.getCurrentStep();
          assert.equal(currentStep.getStartEventId(), 0);
-         assert.equal(currentStep.getEndEventId(), 4);
-         assert.equal(currentStep.getEventIterator().getCount(), 5);
+         assert.equal(currentStep.getEndEventId(), 5);
+         assert.equal(currentStep.getEventIterator().getCount(), 6);
          assert.isNull(currentStep.getFrame());
          playback.play();
        }],
@@ -267,16 +274,16 @@ wtf.replay.graphics.Playback_test =
          var exceptionThrown = false;
          try {
            // Seek forwards to a step with a frame.
-           playback.seekStep(5);
+           playback.seekStep(2);
            currentStep = playback.getCurrentStep();
-           assert.equal(currentStep.getStartEventId(), 9);
+           assert.equal(currentStep.getStartEventId(), 11);
            assert.isNotNull(currentStep.getFrame());
 
            // Now, seek backwards to a step without a frame.
-           playback.seekStep(2);
+           playback.seekStep(1);
            currentStep = playback.getCurrentStep();
-           assert.equal(currentStep.getStartEventId(), 4);
-           assert.isNull(currentStep.getFrame());
+           assert.equal(currentStep.getStartEventId(), 6);
+           assert.isNotNull(currentStep.getFrame());
          } catch (exception) {
            exceptionThrown = true;
          } finally {

--- a/src/wtf/replay/graphics/ui/argumentsdialog.js
+++ b/src/wtf/replay/graphics/ui/argumentsdialog.js
@@ -1,0 +1,230 @@
+/**
+ * Copyright 2013 Google, Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+/**
+ * @fileoverview A dialog screen that allows users to alter event arguments.
+ *
+ * @author chizeng@google.com (Chi Zeng)
+ */
+
+goog.provide('wtf.replay.graphics.ui.ArgumentsDialog');
+
+goog.require('goog.asserts');
+goog.require('goog.dom.TagName');
+goog.require('goog.dom.forms');
+goog.require('goog.events');
+goog.require('goog.events.EventType');
+goog.require('goog.json');
+goog.require('goog.object');
+goog.require('goog.soy');
+goog.require('goog.string');
+goog.require('wtf.replay.graphics.ui.argumentsdialog');
+goog.require('wtf.ui.Dialog');
+
+
+
+/**
+ * A dialog that lets users manipulate arguments of events.
+ *
+ * @param {!wtf.db.EventIterator} it Iterator pointing to the relevant event.
+ * @param {!goog.dom.DomHelper} dom DOM helper.
+ * @constructor
+ * @extends {wtf.ui.Dialog}
+ */
+wtf.replay.graphics.ui.ArgumentsDialog = function(it, dom) {
+  goog.base(this, {
+    modal: true
+  }, /** @type {!Element} */ (dom.getDocument().body), dom);
+
+  // The iterator must point to an event.
+  goog.asserts.assert(!it.done());
+
+  /**
+   * The iterator pointing to the current event.
+   * @type {!wtf.db.EventIterator}
+   * @private
+   */
+  this.eventIterator_ = it;
+
+  // Create the form based on the event.
+  this.createForm_();
+};
+goog.inherits(wtf.replay.graphics.ui.ArgumentsDialog, wtf.ui.Dialog);
+
+
+/**
+ * Events related to the arguments-changing dialog.
+ * @enum {string}
+ */
+wtf.replay.graphics.ui.ArgumentsDialog.EventType = {
+  /**
+   * Arguments were altered. A reset does not count.
+   */
+  ARGUMENTS_ALTERED: goog.events.getUniqueId('arguments_altered'),
+
+  /**
+   * Arguments were reset to their original ones.
+   */
+  ARGUMENTS_RESET: goog.events.getUniqueId('arguments_reset')
+};
+
+
+/**
+ * @override
+ */
+wtf.replay.graphics.ui.ArgumentsDialog.prototype.createDom = function(dom) {
+  return /** @type {!Element} */ (goog.soy.renderAsFragment(
+      wtf.replay.graphics.ui.argumentsdialog.control, null, dom));
+};
+
+
+/**
+ * Create the form that lets users alter arguments.
+ * @private
+ */
+wtf.replay.graphics.ui.ArgumentsDialog.prototype.createForm_ = function() {
+  var domHelper = this.getDom();
+  var eventHandler = this.getHandler();
+
+  var formTitle = /** @type {Element} */ (this.getChildElement(
+      goog.getCssName('title')));
+  domHelper.setTextContent(
+      formTitle, 'Editing ' + this.eventIterator_.getName());
+
+  // Listen for form submission events.
+  var form = /** @type {HTMLFormElement} */ (this.getChildElement(
+      goog.getCssName('form')));
+  var saveButton = this.getChildElement(
+      goog.getCssName('saveArgumentsButton'));
+  var saveFunction = function(e) {
+    e.preventDefault();
+    this.updateArguments_(goog.dom.forms.getFormDataMap(form));
+  };
+
+  // Save the new arguments when either the update button is clicked or Enter
+  // is hit.
+  eventHandler.listen(saveButton, goog.events.EventType.CLICK,
+      saveFunction, false, this);
+  eventHandler.listen(form, goog.events.EventType.SUBMIT,
+      saveFunction, false, this);
+
+  // Create label/input pair elements based on the type of value.
+  var inputsContainer = domHelper.getElementByClass(
+      goog.getCssName('dialogFields'));
+  var argumentValues = this.eventIterator_.getArguments();
+  for (var key in argumentValues) {
+    var labelInputPair = this.createLabelInputPair_(key, argumentValues[key]);
+    domHelper.appendChild(inputsContainer, labelInputPair);
+  }
+
+  // Create the reset arguments button.
+  var resetArgumentsElement = domHelper.getElementByClass(
+      goog.getCssName('resetArgumentsButton'));
+  eventHandler.listen(resetArgumentsElement,
+      goog.events.EventType.CLICK, this.resetArguments_, false, this);
+
+  // Create the cancel button.
+  var cancelButton = domHelper.getElementByClass(
+      goog.getCssName('cancelButton'), this.getRootElement());
+  eventHandler.listen(cancelButton,
+      goog.events.EventType.CLICK, this.close, false, this);
+};
+
+
+/**
+ * Resets the arguments of the event. Then, fires the appropriate event and
+ * closes the dialog.
+ * @private
+ */
+wtf.replay.graphics.ui.ArgumentsDialog.prototype.resetArguments_ = function() {
+  this.eventIterator_.resetArguments();
+  this.emitEvent(
+      wtf.replay.graphics.ui.ArgumentsDialog.EventType.ARGUMENTS_RESET);
+  this.close();
+};
+
+
+/**
+ * Updates the arguments of the event. Then, fires the appropriate event and
+ * closes the dialog.
+ * @param {!goog.structs.Map} newArgumentMap A mapping from the keys of any
+ *     updated arguments to their new values.
+ * @private
+ */
+wtf.replay.graphics.ui.ArgumentsDialog.prototype.updateArguments_ =
+    function(newArgumentMap) {
+  var it = this.eventIterator_;
+  var originalArguments = it.getArguments();
+
+  // Make a copy of the arguments, and update if need be.
+  var newArguments = goog.object.clone(originalArguments);
+  for (var key in originalArguments) {
+    // Update the argument based on its type.
+    switch (typeof originalArguments[key]) {
+      case 'number':
+        var newValue = /** @type {string} */ (newArgumentMap.get(key));
+        newArguments[key] = goog.string.parseInt(newValue);
+        break;
+      case 'string':
+        newArguments[key] = newArgumentMap.get(key);
+        break;
+      default:
+        break;
+    }
+  }
+
+  it.setArguments(newArguments);
+  this.emitEvent(
+      wtf.replay.graphics.ui.ArgumentsDialog.EventType.ARGUMENTS_ALTERED);
+  this.close();
+};
+
+
+/**
+ * Creates an field / input pair given a type of argument.
+ * @param {string} key The argument key.
+ * @param {*} value The value of the argument.
+ * @return {!Element} The label / input pair pertaining to an argument.
+ * @private
+ */
+wtf.replay.graphics.ui.ArgumentsDialog.prototype.createLabelInputPair_ =
+    function(key, value) {
+  var domHelper = this.getDom();
+  var labelInputPair = /** @type {!Element} */ (goog.soy.renderAsFragment(
+      wtf.replay.graphics.ui.argumentsdialog.argumentkeyvaluepair,
+      {argumentKey: key}, domHelper));
+  var inputContainer = domHelper.getElementByClass(
+      goog.getCssName('graphicsReplayArgumentsDialogInputContainer'),
+      labelInputPair);
+
+  // Vary how to display the input based on the type of the value.
+  var inputElement;
+
+  // TODO(chizeng): Find a more reliable way of determining type than typeof.
+  switch (typeof value) {
+    case 'number':
+      inputElement = domHelper.createElement(goog.dom.TagName.INPUT);
+      inputElement.name = key;
+      inputElement.type = 'text';
+      inputElement.value = value;
+      break;
+    case 'string':
+      inputElement = domHelper.createElement(goog.dom.TagName.TEXTAREA);
+      inputElement.name = key;
+      domHelper.setTextContent(inputElement, value);
+      break;
+    default:
+      inputElement = domHelper.createElement(goog.dom.TagName.PRE);
+
+      // Unsupported argument type. Use JSON to make a pretty string to print.
+      domHelper.setTextContent(inputElement, goog.json.serialize(value));
+      break;
+  }
+  domHelper.appendChild(inputContainer, inputElement);
+
+  return labelInputPair;
+};

--- a/src/wtf/replay/graphics/ui/argumentsdialog.less
+++ b/src/wtf/replay/graphics/ui/argumentsdialog.less
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2013 Google, Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+/**
+ * Graphics replay argument-editing dialog LESS file.
+ *
+ * @author chizeng@google.com (Chi Zeng)
+ */
+
+.graphicsReplayArgumentsDialog {
+  .form {
+    .header {
+      .buttons {
+        & .kButton {
+          margin: 0 0 0 16px;
+        }
+      }
+    }
+    .saveArgumentsButton {}
+
+    .resetArgumentsButton {}
+
+    .dialogFields {
+      .graphicsReplayArgumentsDialogArgKeyPair {
+        margin: 15px 0 0 0;
+
+        .graphicsReplayArgumentsDialogInputContainer {}
+      }
+    }
+
+    /* Forms need a submit input element for Enter to work. */
+    .hiddenSubmit {
+      visibility: hidden;
+    }
+  }
+}

--- a/src/wtf/replay/graphics/ui/argumentsdialog.soy
+++ b/src/wtf/replay/graphics/ui/argumentsdialog.soy
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2013 Google, Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+/**
+ * Arguments dialog (the dialog that lets users alter arguments of events) DOM
+ * for graphics replay.
+ *
+ * @author chizeng@google.com (Chi Zeng)
+ */
+
+{namespace wtf.replay.graphics.ui.argumentsdialog}
+
+
+/**
+ * Root control UI of the arguments dialog.
+ */
+{template .control}
+  <div class="{css uiSettingsDialog} {css graphicsReplayArgumentsDialog}">
+    <form class="{css form}">
+      <div class="{css header}">
+        <div class="{css buttons}">
+          <a class="{css kButton} {css kButtonBlue} {css saveArgumentsButton}">Update</a>
+          <a class="{css kButton} {css resetArgumentsButton}">Reset</a>
+          <a class="{css kButton} {css cancelButton}">Cancel</a>
+        </div>
+        <h1 class="{css title}"></h1>
+      </div>
+      <div class="{css contents}">
+        <div>
+          <div class="{css dialogFields}"></div>
+        </div>
+      </div>
+      <!-- Hidden submit button. Makes pressing Enter submit the form. -->
+      <input class="{css hiddenSubmit}" type="submit">
+    </form>
+  </div>
+{/template}
+
+
+/**
+ * A field / input pair for the form on the arguments dialog.
+ * @param argumentKey The key of the argument.
+ */
+{template .argumentkeyvaluepair}
+  <div class="{css graphicsReplayArgumentsDialogArgKeyPair}">
+    <label for="{$argumentKey}">{$argumentKey}:</label>
+    <div class="{css graphicsReplayArgumentsDialogInputContainer}"></div>
+  </div>
+{/template}

--- a/src/wtf/replay/graphics/ui/eventnavigator.js
+++ b/src/wtf/replay/graphics/ui/eventnavigator.js
@@ -44,7 +44,7 @@ wtf.replay.graphics.ui.EventNavigator = function(
    */
   this.tableSource_ =
       new wtf.replay.graphics.ui.EventNavigatorTableSource(
-          playback, eventList);
+          playback, eventList, this.getDom());
   this.registerDisposable(this.tableSource_);
 
   /**

--- a/src/wtf/replay/graphics/ui/graphics.less
+++ b/src/wtf/replay/graphics/ui/graphics.less
@@ -12,6 +12,7 @@
  * @author chizeng@google.com (Chi Zeng)
  */
 
+@import "wtf/replay/graphics/ui/argumentsdialog.less";
 @import "wtf/replay/graphics/ui/canvasarea.less";
 @import "wtf/replay/graphics/ui/contextbox.less";
 @import "wtf/replay/graphics/ui/eventnavigator.less";


### PR DESCRIPTION
The user can now alter the arguments of events. Specifically, when a user clicks on the Edit button next to an event listed in the navigator in graphics replay, a dialog appears that lets the user alter arguments. A reset button lets the user clear any alterations of arguments for an event.
