### PR TITLE
Removed RESOURCES_DONE event.

### DIFF
--- a/src/wtf/replay/graphics/playback.js
+++ b/src/wtf/replay/graphics/playback.js
@@ -238,12 +238,7 @@ wtf.replay.graphics.Playback.EventType = {
    * Playing stopped. Could be due to finishing the animation, pausing,
    * or resetting.
    */
-  PLAY_STOPPED: goog.events.getUniqueId('play_stopped'),
-
-  /**
-   * Resources finished loading.
-   */
-  RESOURCES_DONE: goog.events.getUniqueId('resources_done')
+  PLAY_STOPPED: goog.events.getUniqueId('play_stopped')
 };
 
 
@@ -666,8 +661,6 @@ wtf.replay.graphics.Playback.prototype.fetchResources_ = function() {
 
     // Let user know that resources have finished loading.
     this.resourcesDoneLoading_ = true;
-    this.emitEvent(
-        wtf.replay.graphics.Playback.EventType.RESOURCES_DONE);
   }, this);
   return deferred;
 };
@@ -924,12 +917,13 @@ wtf.replay.graphics.Playback.prototype.seekSubStepEvent = function(index) {
 
 
 /**
- * Gets the 0-based index of the substep event ID or -1 if it does not exist.
- * @return {number} The index of the substep event ID or -1 if it does not
+ * Gets the index of the substep event (which is 0-based from the first event
+ * in the current step) or -1 if the substep event does not exist.
+ * @return {number} The index of the substep event or -1 if it does not
  *     exist (It does not exist if we are not playing within a step or if we
  *     are at the very beginning of a step.).
  */
-wtf.replay.graphics.Playback.prototype.getSubStepEventId = function() {
+wtf.replay.graphics.Playback.prototype.getSubStepEventIndex = function() {
   return this.subStepId_;
 };
 

--- a/src/wtf/replay/graphics/ui/eventnavigator.js
+++ b/src/wtf/replay/graphics/ui/eventnavigator.js
@@ -212,7 +212,7 @@ wtf.replay.graphics.ui.EventNavigator.prototype.setSearchValue_ = function(
  */
 wtf.replay.graphics.ui.EventNavigator.prototype.updateScrolling = function(
     playback) {
-  var rowToScrollTo = playback.getSubStepEventId() + 1;
+  var rowToScrollTo = playback.getSubStepEventIndex() + 1;
   this.table_.scrollToRow(
       rowToScrollTo, wtf.ui.VirtualTable.Alignment.MIDDLE);
 };

--- a/src/wtf/replay/graphics/ui/eventnavigatorsource.js
+++ b/src/wtf/replay/graphics/ui/eventnavigatorsource.js
@@ -254,7 +254,7 @@ wtf.replay.graphics.ui.EventNavigatorTableSource.prototype.paintRowRange =
   var rowCenter = rowHeight / 2 + 10 / 2;
 
   // Iterate ahead to the event represented by the top row displayed.
-  var currentRow = this.playback_.getSubStepEventId();
+  var currentRow = this.playback_.getSubStepEventIndex();
   var contextChangingEvents = currentStep.getContextChangingEvents();
   for (var i = 1; i < first; ++i) {
     it.next();
@@ -500,7 +500,7 @@ wtf.replay.graphics.ui.EventNavigatorTableSource.prototype.onClick =
       // TODO(benvanik): context click?
     } else {
       var soughtIndex = row - 1;
-      if (soughtIndex != playback.getSubStepEventId()) {
+      if (soughtIndex != playback.getSubStepEventIndex()) {
         playback.seekSubStepEvent(soughtIndex);
       }
     }
@@ -580,7 +580,7 @@ wtf.replay.graphics.ui.EventNavigatorTableSource.prototype.markArgsReset_ =
 wtf.replay.graphics.ui.EventNavigatorTableSource.prototype.playbackToCurrent_ =
     function() {
   var playback = this.playback_;
-  var targetIndex = playback.getSubStepEventId();
+  var targetIndex = playback.getSubStepEventIndex();
   playback.seekStep(playback.getCurrentStepIndex());
   playback.seekSubStepEvent(targetIndex);
 };


### PR DESCRIPTION
Since a Deferred is used to indicate when a playback has loaded, Playback does not need to fire a RESOURCES_DONE event, so the event has been removed. Tests have been changed accordingly. getSubStepEventId has also been renamed to getSubStepEventIndex to reflect what it really returns in Playback.
