### PR TITLE
Don't use {} for function name keyed dictionaries.

### DIFF
--- a/src/wtf/db/eventtypetable.js
+++ b/src/wtf/db/eventtypetable.js
@@ -49,7 +49,7 @@ wtf.db.EventTypeTable = function() {
    * @type {!Object.<!wtf.db.EventType>}
    * @private
    */
-  this.eventsByName_ = {};
+  this.eventsByName_ = Object.create(null);
 };
 
 

--- a/src/wtf/ui/color/palette.js
+++ b/src/wtf/ui/color/palette.js
@@ -49,7 +49,7 @@ wtf.ui.color.Palette = function(colors) {
    * @type {!Object.<!wtf.ui.color.RgbColor>}
    * @private
    */
-  this.stringCache_ = {};
+  this.stringCache_ = Object.create(null);
 
   for (var n = 0; n < colors.length; n++) {
     var sourceColor = colors[n];


### PR DESCRIPTION
Use Object.create(null) instead, which creates an object with a null
prototype so that function name keys like "toString", "hasOwnProperty",
etc aren't erroneously found in the prototype.
