### PR TITLE
Resetting a trace from the HUD now resets workers as well.

### DIFF
--- a/src/wtf/hud/hud.js
+++ b/src/wtf/hud/hud.js
@@ -129,6 +129,12 @@ wtf.hud.SessionListener_.prototype.requestSnapshots = goog.nullFunction;
 
 
 /**
+ * @override
+ */
+wtf.hud.SessionListener_.prototype.reset = goog.nullFunction;
+
+
+/**
  * Shows the HUD, if it is hidden.
  */
 wtf.hud.show = function() {

--- a/src/wtf/remote/client.js
+++ b/src/wtf/remote/client.js
@@ -240,3 +240,9 @@ wtf.remote.Client.prototype.sessionStopped = function(session) {
  * @override
  */
 wtf.remote.Client.prototype.requestSnapshots = goog.nullFunction;
+
+
+/**
+ * @override
+ */
+wtf.remote.Client.prototype.reset = goog.nullFunction;

--- a/src/wtf/trace/providers/replayprovider.js
+++ b/src/wtf/trace/providers/replayprovider.js
@@ -126,6 +126,13 @@ wtf.trace.providers.ReplayProvider.prototype.requestSnapshots =
 
 
 /**
+ * @override
+ */
+wtf.trace.providers.ReplayProvider.prototype.reset =
+    goog.nullFunction;
+
+
+/**
  * Re-initializes the Math.random replacement.
  * This should be called at the start of each new session.
  * @private

--- a/src/wtf/trace/providers/webworkerprovider.js
+++ b/src/wtf/trace/providers/webworkerprovider.js
@@ -154,6 +154,16 @@ wtf.trace.providers.WebWorkerProvider.prototype.requestSnapshots = function(
 
 
 /**
+ * @override
+ */
+wtf.trace.providers.WebWorkerProvider.prototype.reset = function() {
+  this.childWorkers_.forEach(function(worker) {
+    worker.reset();
+  });
+};
+
+
+/**
  * Injects MessagePort/MessageChannel.
  * @private
  */
@@ -467,6 +477,10 @@ wtf.trace.providers.WebWorkerProvider.prototype.injectBrowserShim_ =
     return result;
   };
 
+  ProxyWorker.prototype.reset = function() {
+    this.sendMessage('reset');
+  };
+
   this.injectFunction(goog.global, 'Worker', ProxyWorker);
 };
 
@@ -595,6 +609,13 @@ wtf.trace.providers.WebWorkerProvider.prototype.injectProxyWorker_ =
           'id': value['id'],
           'data': data
         }, data[0]);
+        break;
+      case 'reset':
+        // NOTE: due to the async nature of posting messages to workers, the
+        // reset that happens on the worker thread won't happen at *exactly* the
+        // same time, but the work to fix it seems greater than the utility we'd
+        // get.
+        wtf.trace.reset();
         break;
     }
 

--- a/src/wtf/trace/trace.js
+++ b/src/wtf/trace/trace.js
@@ -368,10 +368,7 @@ wtf.trace.snapshotAll = function(callback, opt_scope) {
  */
 wtf.trace.reset = function() {
   var traceManager = wtf.trace.getTraceManager();
-  var session = traceManager.getCurrentSession();
-  if (session instanceof wtf.trace.sessions.SnapshottingSession) {
-    session.reset();
-  }
+  traceManager.reset();
 };
 
 

--- a/src/wtf/trace/tracemanager.js
+++ b/src/wtf/trace/tracemanager.js
@@ -67,6 +67,12 @@ wtf.trace.ISessionListener.prototype.sessionStopped = goog.nullFunction;
 wtf.trace.ISessionListener.prototype.requestSnapshots = goog.nullFunction;
 
 
+/**
+ * Fired when the snapshot should be reset.
+ */
+wtf.trace.ISessionListener.prototype.reset = goog.nullFunction;
+
+
 
 /**
  * Trace manager.
@@ -488,6 +494,20 @@ wtf.trace.TraceManager.prototype.requestSnapshots = function(
     wtf.timing.setImmediate(function() {
       complete();
     });
+  }
+};
+
+
+/**
+ * Resets the snapshot for all sessions.
+ */
+wtf.trace.TraceManager.prototype.reset = function() {
+  var session = this.getCurrentSession();
+  if (session instanceof wtf.trace.sessions.SnapshottingSession) {
+    session.reset();
+  }
+  for (var n = 0; n < this.listeners_.length; n++) {
+    this.listeners_[n].reset();
   }
 };
 


### PR DESCRIPTION
Creates an ISessionListener reset() method and plumbs through reset
calls from the main TraceManager to the worker.

Note that resetting will introduce a bit of skew since the worker will
be reset only after it processes the message from the main thread, but
fixing it to retroactively reset would be much more work for very little
benefit.
