### PR TITLE
Sort zones so that workers are on top.

### DIFF
--- a/src/wtf/app/tracks/trackspanel.js
+++ b/src/wtf/app/tracks/trackspanel.js
@@ -197,6 +197,15 @@ wtf.app.tracks.TracksPanel = function(documentView) {
     goog.array.forEach(zones, this.addZoneTrack_, this);
   }, this);
   var zones = db.getZones();
+
+  // Right now, this will ensure that worker zones (which don't have frames) are
+  // on the top. This is arbitrary, but main thread tracks tend to be deeper, so
+  // it seems reasonable to put that on the bottom.
+  goog.array.sort(zones, function(zoneA, zoneB) {
+    return goog.array.defaultCompare(
+        zoneA.getFrameList().getCount(),
+        zoneB.getFrameList().getCount());
+  });
   goog.array.forEach(zones, this.addZoneTrack_, this);
 
   // Done last so any other handlers are properly registered.


### PR DESCRIPTION
If all zones are available when the TracksPanel initializes, make sure
the one with frames is on the bottom.

(I played with it a bit and decided that this was better than below for us.)
