### PR TITLE
getChildFlows_ should only return immediate children.

### DIFF
--- a/src/wtf/db/eventiterator.js
+++ b/src/wtf/db/eventiterator.js
@@ -758,6 +758,9 @@ wtf.db.EventIterator.prototype.getChildFlows_ = function() {
   var ret = null;
 
   for (; !it.done(); it.next()) {
+    // This should only get immediate children so that the same flow doesn't
+    // associate with multiple scopes.
+    if (!(it.getParent().getId() == this.getId())) continue;
     var type = it.getTypeId() & 0xFFFF;
     if (type == branchId ||
         type == extendId ||


### PR DESCRIPTION
For tooltips and filtering, only return a child flow if it is an
immediate child. This prevents flows from appearing to be associated
with every scope above it in the stack.
