### PR TITLE
retarget the xhr event target to point at the proxy

### DIFF
--- a/src/wtf/trace/providers/xhrprovider.js
+++ b/src/wtf/trace/providers/xhrprovider.js
@@ -209,7 +209,12 @@ wtf.trace.providers.XhrProvider.prototype.injectXhr_ = function() {
   ProxyXMLHttpRequest.prototype.beginTrackingEvent = function(type) {
     var self = this;
     var tracker = function(e) {
-      self['dispatchEvent'](e);
+      var retargettedEvent = Object.create(e, {
+        'target': {
+          'value': self
+        }
+      });
+      self['dispatchEvent'](retargettedEvent);
     };
     this.trackers_[type] = tracker;
     this.handle_.addEventListener(type, tracker, false);


### PR DESCRIPTION
This resolves #469

XHR events will now be shimmed with the target pointing back towards the proy.
