### PR TITLE
fix(wtf-call-tracing): prevent Chrome from making /null requests

### DIFF
--- a/extensions/wtf-injector-chrome/wtf-call-tracing.js
+++ b/extensions/wtf-injector-chrome/wtf-call-tracing.js
@@ -251,6 +251,7 @@ function processScript(el, opt_synchronous, opt_baseUrl) {
           src);
       el['__wtfi__'] = true;
       el.src = null;
+      el.removeAttribute('src');
       el.text = resultText;
       var loadEvent = new Event('load');
       loadEvent.target = el;
@@ -279,6 +280,7 @@ function processScript(el, opt_synchronous, opt_baseUrl) {
       src: opt_baseUrl ? resolveUrl(opt_baseUrl, el.getAttribute('src')) : el.src
     };
     el.src = null;
+    el.removeAttribute('src');
 
     // TODO(benvanik): dispatch to web worker.
     var xhr = new XMLHttpRequest();


### PR DESCRIPTION
The latest version (2014.1.23.1) of the Chrome extension breaks on all apps I've tried because during instrumentation all script tags are transformed into script tags that load scripts from `{base}/null` url.

So given:

``` html
<script src="myScript.js"></script>
```

I end up with

``` html
<script src="null">
  // instrumented contents of myScript.js
  // ...
</script>
```

Because the `src` attribute is still present on the tag when the browser processes it, the browser will ignore the script body and try to make request to "/null" url.
