### PR TITLE
fix(wtf-call-tracing): ignore non-javascript scripts

### DIFF
--- a/extensions/wtf-injector-chrome/wtf-call-tracing.js
+++ b/extensions/wtf-injector-chrome/wtf-call-tracing.js
@@ -26,6 +26,14 @@ var warn = global.console && global.console.warn ?
 
 var ENABLE_CACHING = false;
 
+var SUPPORTED_SCRIPT_TYPES = {
+  '': 1,
+  'text/javascript': 1,
+  'text/ecmascript': 1,
+  'application/javascript': 1,
+  'application/ecmascript': 1
+};
+
 
 global['wtfi'] = global['wtfi'] || {};
 
@@ -214,6 +222,8 @@ function processOrCacheAsync(sourceText, moduleId, options, opt_url, callback) {
  *      input element.
  */
 function processScript(el, opt_synchronous, opt_baseUrl) {
+  if (!(el.type in SUPPORTED_SCRIPT_TYPES)) return el;
+  
   var doc = el.ownerDocument;
   if (el.text || el.innerText) {
     // Synchronous block.


### PR DESCRIPTION
Many libraries (e.g. mustache.js), frameworks (AngularJS) and languages (Dart) use script tag as a container element. In this case the script tag doesn't contain anything that WTF could instrument, so the element should be skipped altogether.
