### PR TITLE
Add a warning when redifining events.

### DIFF
--- a/src/wtf/trace/events.js
+++ b/src/wtf/trace/events.js
@@ -39,6 +39,8 @@ wtf.trace.events.create_ = function(signature, eventClass, flags) {
   var existingEventType = registry.getEventType(name);
   if (existingEventType) {
     // TODO(benvanik): assert the same event type (not a redefinition).
+    goog.global.console.log(
+        'Attempting to redifine ' + name + ', using first definition');
     return existingEventType;
   }
 


### PR DESCRIPTION
Creating an event will reuse an old event with the same name; warn the
user on the console when this happens.
