### PR TITLE
Fixed WebGL restart with multiple identical contexts.

### DIFF
--- a/src/wtf/replay/graphics/contextpool.js
+++ b/src/wtf/replay/graphics/contextpool.js
@@ -121,7 +121,9 @@ wtf.replay.graphics.ContextPool.prototype.getContext =
   var retrievedContext;
   if (contextList && contextList.length) {
     // Since context with desired type and attributes exists, return it.
-    retrievedContext = contextList.pop();
+    // Use shift() instead of pop() - First in, First Out ensures that contexts
+    // are returned in the same order that they were released.
+    retrievedContext = contextList.shift();
     this.resetWebGLContext_(retrievedContext);
   } else {
     // Create a new context.


### PR DESCRIPTION
This fixes restarting WebGL playback with this page: http://threejs.org/examples/webgl_multiple_canvases_grid.html.

Previously, contexts were released and returned again in last in, first out order. Existing WebGL objects were then aligned with different contexts, causing "WebGL: INVALID_OPERATION: bindAttribLocation: object does not belong to this context" type errors.

Once restarting works, overdraw visualization and highlighting can work. These features are almost ready for review/merge, here is a preview:

![multiple-canvases-success_cropped](https://cloud.githubusercontent.com/assets/4010439/3462797/e33647a8-0231-11e4-8fd9-040bd2fa8801.png)
