### PR TITLE
Reset the viewport when drawing with OffscreenSurfaces.

### DIFF
--- a/src/wtf/replay/graphics/offscreensurface.js
+++ b/src/wtf/replay/graphics/offscreensurface.js
@@ -543,6 +543,7 @@ wtf.replay.graphics.OffscreenSurface.prototype.drawTextureInternal = function(
   gl.disable(goog.webgl.SCISSOR_TEST);
   gl.disable(goog.webgl.STENCIL_TEST);
   gl.colorMask(true, true, true, true);
+  gl.viewport(0, 0, this.width, this.height);
 
   if (opt_blend) {
     gl.enable(goog.webgl.BLEND);


### PR DESCRIPTION
Fixes highlight and overdraw at
http://threejs.org/examples/webgl_multiple_views.html.
