### PR TITLE
Optimized mutator lookup, support list of mutators.

### DIFF
--- a/src/wtf/replay/graphics/drawcallvisualizer.js
+++ b/src/wtf/replay/graphics/drawcallvisualizer.js
@@ -280,12 +280,13 @@ wtf.replay.graphics.DrawCallVisualizer.prototype.isVisible = function() {
 
 
 /**
- * Handles operations that should occur before the provided event.
+ * Handles operations that should occur before any event.
  * @param {!wtf.db.EventIterator} it Event iterator.
  * @param {WebGLRenderingContext} gl The context.
+ * @protected
  * @override
  */
-wtf.replay.graphics.DrawCallVisualizer.prototype.handlePreEvent = function(
+wtf.replay.graphics.DrawCallVisualizer.prototype.anyPreEvent = function(
     it, gl) {
   if (this.completed) {
     this.restoreState();
@@ -293,8 +294,6 @@ wtf.replay.graphics.DrawCallVisualizer.prototype.handlePreEvent = function(
   if (!this.active) {
     this.previousVisibility_ = false;
   }
-
-  goog.base(this, 'handlePreEvent', it, gl);
 };
 
 


### PR DESCRIPTION
This commit significantly decreases Visualizer/Mutator overhead in debug mode and slightly decreases overhead in fully compiled mode. I was noticing an average replay time\* of 50ms per frame for a trace (in debug mode) of the [WebGL Aquarium](https://webglsamples.googlecode.com/hg/aquarium/aquarium.html) before this change and I am now seeing closer to 20ms per frame.

Playback already uses eventIds in a similar way (see [constructCallLookupTable_](https://github.com/google/tracing-framework/blob/63e19623aebdf0d25659ccda9877a3aa5393ebe6/src/wtf/replay/graphics/playback.js#L345)).

\* Replay time is timing frame durations during WebGL playback, without JavaScript/network operations. I am currently working on this feature.
