### PR TITLE
Fixed phantom scrolling triggered by mouseout.

### DIFF
--- a/src/wtf/ui/virtualtable.js
+++ b/src/wtf/ui/virtualtable.js
@@ -302,6 +302,9 @@ wtf.ui.VirtualTable.prototype.setupScrolling_ = function() {
   eh.listen(this.scrollTrackEl_, goog.events.EventType.MOUSEUP, function(e) {
     wtf.timing.clearInterval(this.repeatInterval_);
   });
+  eh.listen(this.scrollTrackEl_, goog.events.EventType.MOUSEOUT, function(e) {
+    wtf.timing.clearInterval(this.repeatInterval_);
+  });
 
   // Mouse wheel support. This could use tweaking on OSX where scroll
   // direction is reversed.


### PR DESCRIPTION
Repro of the issue:
1. Click down in any scroll region (not on the bar itself)
2. Move the mouse out of the scroll region
3. Release the mouse button
4. Watch the scroll bar continue scrolling

It can be fun to play with: on the query tab, on a trace [like this one](http://google.github.io/tracing-framework/bin/app/maindisplay.html?url=..%2F..%2Fresources%2Ftraces%2Fblk-server.wtf-trace), search for 'a' and drag off of the scroll region a few times. The rows scroll by faster and faster as`wtf.timing.setInterval` is called multiple times without being cleared.
