### PR TITLE
Added 'type' property to proxy XHR events to quell Firefox.

### DIFF
--- a/src/wtf/trace/providers/xhrprovider.js
+++ b/src/wtf/trace/providers/xhrprovider.js
@@ -211,7 +211,12 @@ wtf.trace.providers.XhrProvider.prototype.injectXhr_ = function() {
     var tracker = function(e) {
       var retargettedEvent = Object.create(e, {
         'target': {
-          'value': self
+          'value': self,
+          'writable': false
+        },
+        'type': {
+          'value': e.type,
+          'writable': false
         }
       });
       self['dispatchEvent'](retargettedEvent);


### PR DESCRIPTION
Firefox now checks if an event object implements the W3C Event interface (http://www.w3.org/TR/DOM-Level-2-Events/events.html#Events-interface) when one of its properties is accessed. The property has to exist on the event object itself - not on an object along the event's prototype chain. If the event object itself lacks the property being accessed, Firefox throws an error.

This pull request does not completely solve the problem of accessing event properties - it only quells the Firefox error when the 'type' attribute is accessed.
