### PR TITLE
Name anonymous property functions

### DIFF
--- a/extensions/wtf-injector-chrome/wtf-process.js
+++ b/extensions/wtf-injector-chrome/wtf-process.js
@@ -79,6 +79,11 @@ global['wtfi']['process'] = function(
       return null;
     }
 
+    // {foo: function() {}}
+    if (node.parent.type == 'Property') {
+      return cleanupName(node.parent.key.name);
+    }
+
     // foo = function() {};
     // Bar.foo = function() {};
     if (node.parent.type == 'AssignmentExpression') {


### PR DESCRIPTION
When instrumenting code, use the property name instead of ‘anonymous<num>’.

``` js
{
  foo: function() {
    // If anonymous, this function will be named ‘foo’.
  }
}
```
