### PR TITLE
Support ipv6 addresses in the extension uri parser.

### DIFF
--- a/extensions/wtf-injector-chrome/uri.js
+++ b/extensions/wtf-injector-chrome/uri.js
@@ -20,12 +20,13 @@ var URI = function() {};
 
 
 /**
- * Douglas Crockford's URL regex from JavaScript: The Good Parts.
+ * Douglas Crockford's URL regex from JavaScript: The Good Parts (modified to
+ * support ipv6 address host names).
  * @const
  * @type {RegExp}
  * @private
  */
-URI.regex_ = /^(?:([A-Za-z-]+):)?(\/{0,3})([0-9.\-A-Za-z]+)(?::(\d+))?(?:\/([^?#]*))?(?:\?([^#]*))?(?:#(.*))?$/;
+URI.regex_ = /^(?:([A-Za-z-]+):)?(\/{0,3})([0-9.\-A-Za-z]+|\[[:0-9A-Za-z]+\])(?::(\d+))?(?:\/([^?#]*))?(?:\?([^#]*))?(?:#(.*))?$/;
 
 
 /**


### PR DESCRIPTION
This fixes an issue where wtf can't be enabled for urls like
"http://[::]/test.html" (which is a perfectly valid url using the ipv6
localhost).