### PR TITLE
Protocol agnostic script link for command.js

### DIFF
--- a/bin/controller.js
+++ b/bin/controller.js
@@ -222,7 +222,7 @@ function main(argv) {
   console.log('  http://' + os.hostname() + ':' + argv['http-port']);
   console.log('');
   console.log('Add this to your page <head> BEFORE anything else:');
-  console.log('<script src="http://google.github.io/tracing-framework/bin/wtf_trace_web_js_compiled.js"></script>');
+  console.log('<script src="//google.github.io/tracing-framework/bin/wtf_trace_web_js_compiled.js"></script>');
   console.log('<script>');
   console.log('  wtf.remote.connect({');
   console.log('    \'wtf.remote.target\': \'' + uri + '\'');


### PR DESCRIPTION
Command.js shouldn't dictate non-ssl wtf js script src.

 * Used protocol agnostic // instead of http to avoid mixed content errors.