### PR TITLE
Added abstractions for platform-specific atomics, mutexes, and lock g…

### DIFF
--- a/bindings/cpp/buffer.cc
+++ b/bindings/cpp/buffer.cc
@@ -47,7 +47,7 @@ void OutputBuffer::StartChunk(ChunkHeader header, PartHeader* parts,
 StringTable::StringTable() = default;
 
 int StringTable::GetStringId(const std::string& str) {
-  std::lock_guard<std::mutex> lock{mu_};
+  platform::lock_guard<platform::mutex> lock{mu_};
   auto it = strings_to_id_.find(str);
   if (it == strings_to_id_.end()) {
     // New string.
@@ -61,7 +61,7 @@ int StringTable::GetStringId(const std::string& str) {
 }
 
 void StringTable::PopulateHeader(OutputBuffer::PartHeader* header) {
-  std::lock_guard<std::mutex> lock{mu_};
+  platform::lock_guard<platform::mutex> lock{mu_};
 
   // Compute size.
   size_t raw_length = 0;
@@ -76,7 +76,7 @@ void StringTable::PopulateHeader(OutputBuffer::PartHeader* header) {
 
 bool StringTable::WriteTo(OutputBuffer::PartHeader* header,
                           OutputBuffer* output_buffer) {
-  std::lock_guard<std::mutex> lock{mu_};
+  platform::lock_guard<platform::mutex> lock{mu_};
 
   // Output up to the previously noted size.
   size_t raw_length = 0;
@@ -98,7 +98,7 @@ bool StringTable::WriteTo(OutputBuffer::PartHeader* header,
 }
 
 void StringTable::Clear() {
-  std::lock_guard<std::mutex> lock{mu_};
+  platform::lock_guard<platform::mutex> lock{mu_};
   strings_.clear();
   strings_to_id_.clear();
 }

--- a/bindings/cpp/event.cc
+++ b/bindings/cpp/event.cc
@@ -13,7 +13,7 @@ const char* ArgTypeDef<uint32_t>::name = "uint32";
 const char* ArgTypeDef<int16_t>::name = "int16";
 const char* ArgTypeDef<int32_t>::name = "int32";
 
-std::atomic<int> EventDefinition::next_event_id_{
+platform::atomic<int> EventDefinition::next_event_id_{
     StandardEvents::kScopeLeaveEventId + 1};
 
 namespace {
@@ -104,12 +104,12 @@ EventRegistry* EventRegistry::GetInstance() {
 
 void EventRegistry::AddEventDefinition(EventDefinition event_definition) {
   EventRegistry* instance = GetInstance();
-  std::lock_guard<std::mutex> lock{instance->mu_};
+  platform::lock_guard<platform::mutex> lock{instance->mu_};
   instance->event_definitions_.push_back(event_definition);
 }
 
 std::vector<EventDefinition> EventRegistry::GetEventDefinitions() {
-  std::lock_guard<std::mutex> lock{mu_};
+  platform::lock_guard<platform::mutex> lock{mu_};
   std::vector<EventDefinition> r;
   r.reserve(event_definitions_.size());
   std::copy(event_definitions_.begin(), event_definitions_.end(),
@@ -140,7 +140,7 @@ void StandardEvents::ScopeLeave(EventBuffer* event_buffer) {
 
 int StandardEvents::CreateZone(EventBuffer* event_buffer, const char* name,
                                const char* type, const char* location) {
-  static std::atomic<int> next_zone_id{1};
+  static platform::atomic<int> next_zone_id{1};
   static EventEnabled<uint16_t, const char*, const char*, const char*> event{
       EventClass::kInstance, EventFlags::kBuiltin | EventFlags::kInternal,
       "wtf.zone#create:zoneId,name,type,location"};

--- a/bindings/cpp/include/wtf/buffer.h
+++ b/bindings/cpp/include/wtf/buffer.h
@@ -1,13 +1,13 @@
 #ifndef TRACING_FRAMEWORK_BINDINGS_CPP_INCLUDE_WTF_BUFFER_H_
 #define TRACING_FRAMEWORK_BINDINGS_CPP_INCLUDE_WTF_BUFFER_H_
 
-#include <atomic>
 #include <deque>
 #include <iostream>
-#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <vector>
+
+#include "wtf/platform.h"
 
 namespace wtf {
 
@@ -105,7 +105,7 @@ class StringTable {
   void Clear();
 
  private:
-  std::mutex mu_;
+  platform::mutex mu_;
   std::vector<std::string> strings_;
   std::unordered_map<std::string, int> strings_to_id_;
 };
@@ -162,7 +162,7 @@ class EventBuffer {
   static constexpr size_t kInitialSize = 1024;
   StringTable* string_table_;
   std::deque<uint32_t> entries_{kInitialSize};
-  std::atomic<bool> out_of_scope_{false};
+  platform::atomic<bool> out_of_scope_{false};
 };
 
 }  // namespace wtf

--- a/bindings/cpp/include/wtf/event.h
+++ b/bindings/cpp/include/wtf/event.h
@@ -1,9 +1,7 @@
 #ifndef TRACING_FRAMEWORK_BINDINGS_CPP_INCLUDE_WTF_EVENT_H_
 #define TRACING_FRAMEWORK_BINDINGS_CPP_INCLUDE_WTF_EVENT_H_
 
-#include <atomic>
 #include <functional>
-#include <mutex>
 #include <string>
 
 #include "wtf/buffer.h"
@@ -164,7 +162,7 @@ class EventDefinition {
                           const char* next_arg_type, const char** arg_names);
 
   // Hands out event ids.
-  static std::atomic<int> next_event_id_;
+  static platform::atomic<int> next_event_id_;
 
   int wire_id_ = 0;
   EventClass event_class_ = EventClass::kInstance;
@@ -191,7 +189,7 @@ class EventRegistry {
   std::vector<EventDefinition> GetEventDefinitions();
 
  private:
-  std::mutex mu_;
+  platform::mutex mu_;
   std::deque<EventDefinition> event_definitions_;
   EventRegistry();
   EventRegistry(const EventRegistry&) = delete;

--- a/bindings/cpp/include/wtf/platform/platform_aux_pthread_inl.h
+++ b/bindings/cpp/include/wtf/platform/platform_aux_pthread_inl.h
@@ -4,9 +4,24 @@
 #ifndef TRACING_FRAMEWORK_BINDINGS_CPP_INCLUDE_WTF_PLATFORM_AUX_PTHREAD_INL_H_
 #define TRACING_FRAMEWORK_BINDINGS_CPP_INCLUDE_WTF_PLATFORM_AUX_PTHREAD_INL_H_
 
+#include <atomic>
+#include <mutex>
+
+// TODO(wcraddock, laurenzo): Begin using the C++11 thread interface.
 #include <pthread.h>
 
 namespace wtf {
+
+// On this platform, use the standard-library versions of atomics and mutexes.
+namespace platform {
+using mutex = std::mutex;
+
+template <typename T>
+using lock_guard = std::lock_guard<T>;
+
+template <typename T>
+using atomic = std::atomic<T>;
+}  // namespace platform
 
 namespace internal {
 extern pthread_key_t event_buffer_key;

--- a/bindings/cpp/include/wtf/runtime.h
+++ b/bindings/cpp/include/wtf/runtime.h
@@ -3,7 +3,6 @@
 
 #include <iostream>
 #include <memory>
-#include <mutex>
 #include <vector>
 
 #include "wtf/buffer.h"
@@ -60,7 +59,7 @@ class Runtime {
   // Writes the header chunk.
   void WriteHeaderChunk(OutputBuffer* output_buffer);
 
-  std::mutex mu_;
+  platform::mutex mu_;
   StringTable shared_string_table_;
   std::vector<std::unique_ptr<EventBuffer>> thread_event_buffers_;
 };

--- a/bindings/cpp/runtime.cc
+++ b/bindings/cpp/runtime.cc
@@ -38,7 +38,7 @@ void Runtime::EnableCurrentThread(const char* thread_name, const char* type,
   }
   EventBuffer* event_buffer;
   {
-    std::lock_guard<std::mutex> lock{mu_};
+    platform::lock_guard<platform::mutex> lock{mu_};
     event_buffer = CreateThreadEventBuffer();
   }
 
@@ -112,7 +112,7 @@ bool Runtime::Save(std::ostream* out) {
   // lock free.
   std::vector<EventBuffer*> local_thread_event_buffers;
   {
-    std::lock_guard<std::mutex> lock{mu_};
+    platform::lock_guard<platform::mutex> lock{mu_};
     local_thread_event_buffers.reserve(thread_event_buffers_.size());
     for (auto& event_buffer : thread_event_buffers_) {
       local_thread_event_buffers.push_back(event_buffer.get());


### PR DESCRIPTION
Added abstractions for platform-specific atomics, mutexes, and lock guards.

This sets the stage for a later commit that will add support for single-threaded operation on platforms that lack C++11 atomics and mutexes.