### PR TITLE
Build fixes for iOS and Android

### DIFF
--- a/bindings/cpp/event.cc
+++ b/bindings/cpp/event.cc
@@ -57,8 +57,12 @@ bool PeelArgName(const char** arg_names, const char** out_arg_name,
 }  // namespace
 
 void EventDefinition::AppendName(std::string* output) const {
-  const char* colon = strchrnul(name_spec_, ':');
-  output->append(name_spec_, 0, (colon - name_spec_));
+  const char* colon = strchr(name_spec_, ':');
+  if (colon) {
+    output->append(name_spec_, (colon - name_spec_));
+  } else {
+    output->append(name_spec_);
+  }
 }
 
 void EventDefinition::AppendArguments(std::string* output) const {

--- a/bindings/cpp/include/wtf/platform/platform_default_inl.h
+++ b/bindings/cpp/include/wtf/platform/platform_default_inl.h
@@ -1,20 +1,16 @@
 #ifndef TRACING_FRAMEWORK_BINDINGS_CPP_INCLUDE_WTF_PLATFORM_DEFAULT_INL_H_
 #define TRACING_FRAMEWORK_BINDINGS_CPP_INCLUDE_WTF_PLATFORM_DEFAULT_INL_H_
 
-#include <time.h>
+#include <chrono>
 
 namespace wtf {
 
 namespace internal {
 extern uint64_t base_timestamp_nanos;
-static const uint64_t kNanosecondsPerSecond = 1000000000;
 
 inline uint64_t GetNanoTime() {
-  struct timespec ts;
-  clock_gettime(CLOCK_MONOTONIC, &ts);
-
-  return static_cast<uint64_t>(ts.tv_sec) * kNanosecondsPerSecond +
-         static_cast<uint64_t>(ts.tv_nsec);
+  auto duration = std::chrono::steady_clock::now().time_since_epoch();
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(duration).count();
 }
 
 }  // namespace internal


### PR DESCRIPTION
Replace strchrnul usage with strchr (and avoid implicit conversion from name_spec_ to intermediate std::string value).

Adopt <chrono> for timing. (Note that steady_clock is not guaranteed to provide nanosecond resolution, but it does on Linux/Android and iOS, at least. And high_resolution_clock is not guaranteed to be monotonic.)