### PR TITLE
Enables lock free asynchronous reset of thread event buffers.

### DIFF
--- a/bindings/cpp/Makefile
+++ b/bindings/cpp/Makefile
@@ -103,7 +103,7 @@ test: macros_test runtime_test threaded_torture_test
 	./runtime_test
 ifeq "$(THREADING)" "multi"
 	@echo "Running threaded_torture_test"
-	./threaded_torture_test
+	time ./threaded_torture_test
 endif
 
 gtest.o: $(GTEST_ALL_CC)

--- a/bindings/cpp/include/wtf/buffer.h
+++ b/bindings/cpp/include/wtf/buffer.h
@@ -193,6 +193,18 @@ class EventBuffer {
     return slots;
   }
 
+  // To be called after initial slots have been added. They will be transferred
+  // to frozen_prefix_slots_ and cleared from the EventBuffer proper. This
+  // must be done prior to ordinary use of the EventBuffer. It is not possible
+  // to freeze a prefix that spans beyond one chunk.
+  void FreezePrefixSlots();
+
+  // Gets the frozen prefix slots that must be appended whenever the EventBuffer
+  // is serialized.
+  const std::vector<uint32_t>& frozen_prefix_slots() {
+    return frozen_prefix_slots_;
+  }
+
   // Flushes all pending calls to WriteSlots once data has been written. Note
   // that certain operations (i.e. chunk overflow) can cause flushing to
   // happen earlier.
@@ -246,6 +258,11 @@ class EventBuffer {
   StringTable* string_table_;
   size_t chunk_limit_;
   platform::atomic<bool> out_of_scope_{false};
+
+  // Frozen slots that must be prepended whenever the EventBuffer is written
+  // out. This contains any setup events that are needed when writing out
+  // an EventBuffer and will be set at initialization time.
+  std::vector<uint32_t> frozen_prefix_slots_;
 
   // The head chunk. This is set at allocation time prior to the instance
   // becoming shared. The last chunk in the list is the only one that will

--- a/bindings/cpp/include/wtf/buffer.h
+++ b/bindings/cpp/include/wtf/buffer.h
@@ -143,20 +143,24 @@ class EventBuffer {
     // Access: Writer thread only.
     size_t size = 0;
 
-    // The size as visible to readers.
-    // Access: Written by writer, read by reader.
-    platform::atomic<size_t> published_size{0};
-
     // The array of slots (allocated 'limit' entries).
     // Access: Reader and writer threads.
     // Guarantees: All indices reported by published_size are consistent for
     // access from the reader thread.
     uint32_t* slots;
 
+    // The size as visible to readers.
+    // Access: Written by writer, read by reader.
+    platform::atomic<size_t> published_size{0};
+
     // The next chunk, if any.
     // Access: Written by writer as the last step of initializing a new
     // chunk. Read by reader when dumping the buffer.
     platform::atomic<Chunk*> next{nullptr};
+
+    // The number of slots that the reader should skip.
+    // Access: Read and written by reader.
+    size_t skip_count = 0;
   };
 
   // Disallow copy/assignment.
@@ -228,11 +232,15 @@ class EventBuffer {
   // populated via PopulateHeader(). Note that the buffer may have grown
   // since the time of PopulateHeader() and only the amount noted there will
   // be written.
+  // This method can optionally clear data as it is writing. In this mode,
+  // it is valid to pass output_buffer == nullptr, which does a dummy write
+  // and clears.
   // NOTE: No verification is done to ensure that the buffer is in a
   // consistent state. In general, it should be assumed that full transactions
   // are present but there may be unbalanced enter/leaves.
   // Returns: Whether the buffer was serialized properly.
-  bool WriteTo(OutputBuffer::PartHeader* header, OutputBuffer* output_buffer);
+  bool WriteTo(OutputBuffer::PartHeader* header, OutputBuffer* output_buffer,
+               bool clear_written_data);
 
   // Whether the event buffer is empty. It is only valid to call this from the
   // hosting thread.

--- a/bindings/cpp/include/wtf/runtime.h
+++ b/bindings/cpp/include/wtf/runtime.h
@@ -17,6 +17,23 @@ namespace wtf {
 // All functionality of this class is thread safe.
 class Runtime {
  public:
+  // Options controlling save.
+  struct SaveOptions {
+    SaveOptions() : clear_thread_data(false) {}
+    SaveOptions(bool clear_thread_data)
+        : clear_thread_data(clear_thread_data) {}
+
+    // Clear saved thread data. Note that this will not clear shared data,
+    // which currently includes the string table and event registration buffers.
+    bool clear_thread_data;
+  };
+
+  // Default save options.
+  static const SaveOptions kSaveOptionsDefault;
+
+  // Save options that clear thread data.
+  static const SaveOptions kSaveOptionsClearThreadData;
+
   // Gets the singleton instance.
   // Note that calling through to the instance is reserved for "heavy-weight"
   // operations. Logging events happens without involving this instance.
@@ -36,12 +53,19 @@ class Runtime {
   // points that are unavoidable.
   // Returns: Whether the trace was saved properly (covers both logical and
   // IO errors).
-  bool Save(std::ostream* out);
+  bool Save(std::ostream* out,
+            const SaveOptions& save_options = kSaveOptionsDefault);
 
   // Shortcut to Save(ostream) that saves to a file.
   // Returns: Whether the trace was saved properly (covers both logical and
   // IO errors).
-  bool SaveToFile(const std::string& file_name);
+  bool SaveToFile(const std::string& file_name,
+                  const SaveOptions& save_options = kSaveOptionsDefault);
+
+  // Asynchronously clears thread data. This is similar to passing
+  // a clear_thread_data option to a Save() method, except that when doing it
+  // at save time, only the saved data is cleared.
+  void ClearThreadData();
 
   // Resets the WTF runtime state. This is intended for testing and may fail
   // or cause crashes if called when asynchronous logging is not quiesced.

--- a/bindings/cpp/runtime.cc
+++ b/bindings/cpp/runtime.cc
@@ -44,6 +44,7 @@ void Runtime::EnableCurrentThread(const char* thread_name, const char* type,
   int zone_id =
       StandardEvents::CreateZone(event_buffer, thread_name, type, location);
   StandardEvents::SetZone(event_buffer, zone_id);
+  event_buffer->FreezePrefixSlots();
   PlatformSetThreadLocalEventBuffer(event_buffer);
 }
 

--- a/bindings/cpp/threaded_torture_test.cc
+++ b/bindings/cpp/threaded_torture_test.cc
@@ -12,13 +12,14 @@ std::vector<std::string> thread_names;
 
 void SaveThread() {
   WTF_THREAD_ENABLE("SaveThread");
-  for (int i = 0; i < 751; i++) {
+  for (int i = 0; i < 1001; i++) {
     if (i > 0 && (i % 250) == 0) {
       // Actually save to a file.
       WTF_SCOPE("SaveThread#ToFile: i", int32_t)(i);
       std::stringstream name;
       name << "tmp_threaded_torture_test_" << i << ".wtf-trace";
-      if (!wtf::Runtime::GetInstance()->SaveToFile(name.str())) {
+      if (!wtf::Runtime::GetInstance()->SaveToFile(
+              name.str(), wtf::Runtime::kSaveOptionsClearThreadData)) {
         std::cerr << "SaveToFile() failed" << std::endl;
         had_error = true;
       }

--- a/bindings/cpp/threaded_torture_test.cc
+++ b/bindings/cpp/threaded_torture_test.cc
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <iostream>
 #include <sstream>
 #include <thread>
@@ -40,20 +41,20 @@ void SaveThread() {
 void NoiseMaker1(int thread_number) {
   WTF_THREAD_ENABLE(thread_names[thread_number].c_str());
   for (int i = 0;; i++) {
-    WTF_EVENT("NoiseMaker1#Loop: thread_number, i", int32_t, int32_t)(
-        thread_number, i);
+    WTF_EVENT("NoiseMaker1#Loop: thread_number, i", int32_t, int32_t)
+    (thread_number, i);
     std::this_thread::sleep_for(std::chrono::microseconds(5));
     if ((i % 100) == 0) {
-      WTF_SCOPE("NoiseMaker1#Scope100: thread_number, i", int32_t, int32_t)(
-          thread_number, i);
+      WTF_SCOPE("NoiseMaker1#Scope100: thread_number, i", int32_t, int32_t)
+      (thread_number, i);
       std::this_thread::sleep_for(std::chrono::microseconds(10));
       if ((i % 400) == 0) {
-        WTF_SCOPE("NoiseMaker1#Scope400: thread_number, i", int32_t, int32_t)(
-            thread_number, i);
+        WTF_SCOPE("NoiseMaker1#Scope400: thread_number, i", int32_t, int32_t)
+        (thread_number, i);
         std::this_thread::sleep_for(std::chrono::microseconds(10));
         if ((i % 1600) == 0) {
-          WTF_SCOPE("NoiseMaker1#Scope1600: thread_number, i", int32_t,
-                    int32_t)(thread_number, i);
+          WTF_SCOPE("NoiseMaker1#Scope1600: thread_number, i", int32_t, int32_t)
+          (thread_number, i);
           std::this_thread::sleep_for(std::chrono::microseconds(10));
         }
       }
@@ -68,7 +69,7 @@ extern "C" int main(int argc, char** argv) {
   std::thread save_thread(SaveThread);
 
   std::vector<std::thread> threads;
-  int thread_count = std::thread::hardware_concurrency();
+  int thread_count = std::min(std::thread::hardware_concurrency(), 4u);
   if (thread_count > 1) {
     thread_count -= 1;  // Give one to the save thread if we have it.
   }


### PR DESCRIPTION
This first step gives us the ability to periodically dump out trace files safely. Next up:
  - Add the time base support we discussed to allow larger time spans.
  - Rework saving to write a chunk per thread with thread-local string tables and a shared EventBuffer.
  - Streaming mode where we can send snapshot updates as new chunks.