### PR TITLE
Write out a chunk per thread plus one for the shared event definitions.

### DIFF
--- a/bindings/cpp/buffer.cc
+++ b/bindings/cpp/buffer.cc
@@ -103,8 +103,7 @@ void StringTable::Clear() {
   strings_to_id_.clear();
 }
 
-EventBuffer::EventBuffer(StringTable* string_table, size_t chunk_size_bytes)
-    : string_table_(string_table) {
+EventBuffer::EventBuffer(size_t chunk_size_bytes) {
   if (chunk_size_bytes < kMinimumChunkSizeBytes) {
     chunk_size_bytes = kMinimumChunkSizeBytes;
   }

--- a/bindings/cpp/include/wtf/buffer.h
+++ b/bindings/cpp/include/wtf/buffer.h
@@ -171,11 +171,10 @@ class EventBuffer {
   // remain valid through the life of the instance) and custom chunk size,
   // which specifies how much space is reserved and how much the buffer
   // expands by on overflow.
-  EventBuffer(StringTable* string_table, size_t chunk_size_bytes);
+  EventBuffer(size_t chunk_size_bytes);
 
   // Initialize with a StringTable and defaults.
-  explicit EventBuffer(StringTable* string_table)
-      : EventBuffer(string_table, kDefaultChunkSizeBytes) {}
+  explicit EventBuffer() : EventBuffer(kDefaultChunkSizeBytes) {}
   ~EventBuffer();
 
   // Gets a pointer to a location where 'count' slots can be written, increasing
@@ -219,7 +218,7 @@ class EventBuffer {
   }
 
   // Gets the string table for this buffer.
-  StringTable* string_table() { return string_table_; }
+  StringTable* string_table() { return &string_table_; }
 
   // When the thread owning an EventBuffer dies, it may call this method,
   // which will allow the system to release the EventBuffer.
@@ -263,7 +262,7 @@ class EventBuffer {
   // This is only called in the overflow case of AddSlots().
   uint32_t* ExpandAndAddSlots(size_t count);
 
-  StringTable* string_table_;
+  StringTable string_table_;
   size_t chunk_limit_;
   platform::atomic<bool> out_of_scope_{false};
 

--- a/bindings/cpp/include/wtf/runtime.h
+++ b/bindings/cpp/include/wtf/runtime.h
@@ -80,11 +80,7 @@ class Runtime {
   // of owned instances.
   EventBuffer* CreateThreadEventBuffer();
 
-  // Writes the header chunk.
-  void WriteHeaderChunk(OutputBuffer* output_buffer);
-
   platform::mutex mu_;
-  StringTable shared_string_table_;
   std::vector<std::unique_ptr<EventBuffer>> thread_event_buffers_;
 };
 


### PR DESCRIPTION
This also eliminates the shared string table. Thread specific string tables are currently not pruned on clear. This is tricky and will be done in a followup.