### PR TITLE
Remove ambiguous description of CLA

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Have a fix or feature? Submit a pull request - we love them!
 
 ## Paperwork
 
-As this is a Google project, you *must* first e-sign the [Google Contributor License Agreement](https://developers.google.com/open-source/cla/individual) before we can accept any code. It takes only a second and basically just says you won't sue us or claim copyright of your submitted code. You only need to do this once for any Google project.
+As this is a Google project, you *must* first e-sign the [Google Contributor License Agreement](https://developers.google.com/open-source/cla/individual) before we can accept any code. You only need to do this once for any Google project.
 
 ## Style
 


### PR DESCRIPTION
The part removed is ambiguous, and at least in the current CLA that I just signed, the contributor keeps copyright but grants license to other parties - which is not what this description implies.