### PR TITLE
Updated link to Google JavaScript Style Guide

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,7 +18,7 @@
 	url = https://github.com/necolas/normalize.css.git
 [submodule "third_party/closure-library"]
 	path = third_party/closure-library
-	url = https://code.google.com/p/closure-library/
+	url = https://github.com/google/closure-library.git
 [submodule "third_party/firefox-addon-sdk"]
 	path = third_party/firefox-addon-sdk
 	url = https://github.com/mozilla/addon-sdk.git

--- a/docs/style_guide.md
+++ b/docs/style_guide.md
@@ -4,7 +4,7 @@
 
 Two documents of interest:
 
-* [Google JavaScript Style Guide](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml)
+* [Google JavaScript Style Guide](https://google.github.io/styleguide/javascriptguide.xml)
 * [Annotating JavaScript for the Closure Compiler](https://developers.google.com/closure/compiler/docs/js-for-compiler)
 
 Settings for your editor:


### PR DESCRIPTION
URL "http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml" was not found so I updated it to the corresponding URL on GitHub.
