### PR TITLE
Wrapped non-Blob types passed to Blob constructors with a Blob constructor.

### DIFF
--- a/bin/controller.html
+++ b/bin/controller.html
@@ -144,7 +144,15 @@
       Client.prototype.downloadData = function(filename, mimeType, buffers) {
         // This code comes from wtf.pal.BrowserPlatform#writeBinaryFile.
 
-        var blob = new Blob(buffers, {
+        // Some arbitrary combo of types can cause Chrome to sad tab. Converting
+        // buffers to blobs may prevent this.
+        // TODO(chihuahua): Remove this patch once this is resolved:
+        // https://bugs.chromium.org/p/chromium/issues/detail?id=619217
+        var parts = buffers.map(function(buffer) {
+          return buffer instanceof Blob ? buffer : new Blob([buffer]);
+        });
+
+        var blob = new Blob(parts, {
           'type': mimeType || 'application/octet-stream'
         });
 

--- a/bin/instrument.js
+++ b/bin/instrument.js
@@ -282,7 +282,16 @@ function transformCode(moduleId, url, sourceCode, argv) {
     global.__saveTrace = function(opt_filename) {
       // Grab trace blob URL.
       var buffers = global.__grabTrace();
-      var blob = new Blob(buffers, {
+
+      // Some arbitrary combo of types can cause Chrome to sad tab. Converting
+      // buffers to blobs may prevent this.
+      // TODO(chihuahua): Remove this patch once this is resolved:
+      // https://bugs.chromium.org/p/chromium/issues/detail?id=619217
+      var parts = buffers.map(function(buffer) {
+        return buffer instanceof Blob ? buffer : new Blob([buffer]);
+      });
+
+      var blob = new Blob(parts, {
         type: 'application/octet-stream'
       });
       var url = URL.createObjectURL(blob);

--- a/extensions/wtf-injector-chrome/wtf-call-tracing.js
+++ b/extensions/wtf-injector-chrome/wtf-call-tracing.js
@@ -223,7 +223,7 @@ function processOrCacheAsync(sourceText, moduleId, options, opt_url, callback) {
  */
 function processScript(el, opt_synchronous, opt_baseUrl) {
   if (!(el.type in SUPPORTED_SCRIPT_TYPES)) return el;
-  
+
   var doc = el.ownerDocument;
   if (el.text || el.innerText) {
     // Synchronous block.
@@ -779,7 +779,16 @@ function runSharedInitCode(targetWindow, options) {
   targetWindow.__saveTrace = function(opt_filename) {
     // Grab trace blob URL.
     var buffers = targetWindow.__grabTrace();
-    var blob = new Blob(buffers, {
+
+    // Some arbitrary combo of types can cause Chrome to sad tab. Converting
+    // buffers to blobs may prevent this.
+    // TODO(chihuahua): Remove this patch once this is resolved:
+    // https://bugs.chromium.org/p/chromium/issues/detail?id=619217
+    var parts = buffers.map(function(buffer) {
+      return buffer instanceof Blob ? buffer : new Blob([buffer]);
+    });
+
+    var blob = new Blob(parts, {
       type: 'application/octet-stream'
     });
     var url = URL.createObjectURL(blob);

--- a/src/wtf/io/blob.js
+++ b/src/wtf/io/blob.js
@@ -177,6 +177,12 @@ wtf.io.Blob.toNativeParts = function(parts) {
         }
         part = part.buffer;
       }
+
+      // Some arbitrary combo of types can cause Chrome to sad tab. Converting
+      // buffers to blobs may prevent this.
+      // TODO(chihuahua): Remove this patch once this is resolved:
+      // https://bugs.chromium.org/p/chromium/issues/detail?id=619217
+      part = new Blob([part]);
     }
     result[n] = part;
   }


### PR DESCRIPTION
An arbitrary combo of types fed into the Blob constructor can sad-tab Chrome:  
https://bugs.chromium.org/p/chromium/issues/detail?id=619217

Individually wrapped those types with the Blob constructor (as a temporary patch).

I looked up uses of "new Blob" within the repo and guarded places that seemed relevant:
https://github.com/google/tracing-framework/search?utf8=%E2%9C%93&q=%22new+Blob%22&type=Code