### PR TITLE
Properly name anonymous property functions

### DIFF
--- a/extensions/wtf-injector-chrome/wtf-process.js
+++ b/extensions/wtf-injector-chrome/wtf-process.js
@@ -80,8 +80,10 @@ global['wtfi']['process'] = function(
     }
 
     // {foo: function() {}}
+    // {"foo": function() {}}
+    // {1: function() {}}
     if (node.parent.type == 'Property') {
-      return cleanupName(node.parent.key.name);
+      return cleanupName(node.parent.key.name || ''+node.parent.key.value);
     }
 
     // foo = function() {};


### PR DESCRIPTION
Related to dae91a900b967ec44cf437f50efc1a1b20f4f795 which didn't take following use-cases into account:

```
{"foo": function() {}}
{1: function() {}}
```

The code with the above pattern(s) is often generated by WebPack and without this fix no project built with WebPack can be automatically instrumented with WTF.