### PR TITLE
add more chars to escape when populating searchbox

### DIFF
--- a/src/wtf/app/tracks/trackinfobar.js
+++ b/src/wtf/app/tracks/trackinfobar.js
@@ -155,7 +155,7 @@ wtf.app.tracks.TrackInfoBar = function(tracksPanel, parentElement) {
           // TODO(benvanik): escape other characters?
           filterString =
               '/^' +
-              filterString.replace(/([\.\$\-\*\+])/g, '\\$1') +
+              filterString.replace(/([\.\$\-\*\+\[\]\(\)\{\}])/g, '\\$1') +
               '$/';
         }
         var parsed = this.selection_.setFilterExpression(filterString);


### PR DESCRIPTION
If you use C++ bindings and __PRETTY_FUNCTION__ to generate the name of the scope, you end up with things like
```
    void *foo(bool)
```
as scope names.  And for objectiveC you have things like
```
    [MyClass setThing]
```
And I'm sure there's some situation in which { } might be used by someone too.