### PR TITLE
Don't strip colons in WTF name specs if no arguments are expected.

### DIFF
--- a/bindings/cpp/event.cc
+++ b/bindings/cpp/event.cc
@@ -56,20 +56,23 @@ void EventDefinition::AppendName(std::string* output) const {
   // names, as with the __PRETTY_FUNCTION__ built-in macro.
   // Replace double colons with '#', which is WTF's class/namespace separator.
   //
-  // A single : in a name_spec separates the name part from arguments.
+  // A single : in a name_spec separates the name part from arguments,
+  // if there are arguments.
   const char *src = name_spec_;
-  const char* colon = strchr(src, ':');
-  while (colon) {
-    output->append(src, (colon - src));
-    src = colon + 1;
-    if (*src == ':') {
-      // Double colon, replace with # and continue.
-      output->append("#");
-      src += 1;
-      colon = strchr(src, ':');
-    } else {
-      // This was a single colon.  Output no more.
-      return;
+  if (argument_zipper_) {
+    const char* colon = strchr(src, ':');
+    while (colon) {
+      output->append(src, (colon - src));
+      src = colon + 1;
+      if (*src == ':') {
+        // Double colon, just output it and continue.
+        output->append("::");
+        src += 1;
+        colon = strchr(src, ':');
+      } else {
+        // This was a single colon.  Output no more.
+        return;
+      }
     }
   }
   // Append anything remaining in src.

--- a/bindings/cpp/event_test.cc
+++ b/bindings/cpp/event_test.cc
@@ -15,6 +15,11 @@ class EventTest : public ::testing::Test {
     return EventDefinition::Create<int, const char*>(
         /*wire_id=*/0, EventClass::kScoped, /*flags=*/0, name_spec);
   }
+
+  EventDefinition CreateEventDefinition0(const char *name_spec) {
+    return EventDefinition::Create(
+        /*wire_id=*/0, EventClass::kScoped, /*flags=*/0, name_spec);
+  }
 };
 
 
@@ -31,7 +36,7 @@ TEST_F(EventTest, CheckNameSpecParsing) {
   output.clear();
   event = CreateEventDefinition("MyNamespace::MyClass::MyFunc");
   event.AppendName(&output);
-  EXPECT_EQ(output, "MyNamespace#MyClass#MyFunc");
+  EXPECT_EQ(output, "MyNamespace::MyClass::MyFunc");
   output.clear();
   event.AppendArguments(&output);
   EXPECT_EQ(output, "int32 a0, ascii a1");
@@ -39,7 +44,7 @@ TEST_F(EventTest, CheckNameSpecParsing) {
   output.clear();
   event = CreateEventDefinition("MyClass::MyFunc2:  arg1 , arg2");
   event.AppendName(&output);
-  EXPECT_EQ(output, "MyClass#MyFunc2");
+  EXPECT_EQ(output, "MyClass::MyFunc2");
   output.clear();
   event.AppendArguments(&output);
   EXPECT_EQ(output, "int32 arg1, ascii arg2");
@@ -59,6 +64,22 @@ TEST_F(EventTest, CheckNameSpecParsing) {
   output.clear();
   event.AppendArguments(&output);
   EXPECT_EQ(output, "int32 arg1, ascii a1");
+
+  output.clear();
+  event = CreateEventDefinition0("MyMethodNoArgs");
+  event.AppendName(&output);
+  EXPECT_EQ(output, "MyMethodNoArgs");
+  output.clear();
+  event.AppendArguments(&output);
+  EXPECT_EQ(output, "");
+
+  output.clear();
+  event = CreateEventDefinition0("-[MyMethod looksLikeObjC:hasColons:]");
+  event.AppendName(&output);
+  EXPECT_EQ(output, "-[MyMethod looksLikeObjC:hasColons:]");
+  output.clear();
+  event.AppendArguments(&output);
+  EXPECT_EQ(output, "");
 }
 
 }  // namespace

--- a/bindings/cpp/include/wtf/event.h
+++ b/bindings/cpp/include/wtf/event.h
@@ -183,6 +183,14 @@ class EventDefinition {
   ArgumentZipperCallback argument_zipper_ = nullptr;
 };
 
+// Explicit EventDefinition::Create() specialization for zero ArgTypes.
+// It creates an EventDefinition with a nullptr ArgumentZipper.
+template <>
+inline EventDefinition EventDefinition::Create(
+    int wire_id, EventClass event_class, int flags, const char* name_spec) {
+  return EventDefinition{wire_id, event_class, flags, name_spec, nullptr};
+}
+
 // Singleton registry of all EventDefinitions.
 // The registry is thread safe.
 class EventRegistry {


### PR DESCRIPTION
This fixes the problem I have with standard ObjC method names containing colons, while hopefully not messing colon usage up for anyone who uses it now.

Also don't replace '::' with '#' automatically. I thought having colons would mess WTF up, but it seems to handle them fine.

[patch of commit to google internal repo]