### PR TITLE
Change once_flag.flag brace initialization to assignment.

### DIFF
--- a/bindings/cpp/include/wtf/platform/platform_aux_pthreads_threaded_inl.h
+++ b/bindings/cpp/include/wtf/platform/platform_aux_pthreads_threaded_inl.h
@@ -30,7 +30,7 @@ using std::memory_order_relaxed;
 using std::memory_order_release;
 using std::memory_order_seq_cst;
 
-using once_flag = struct { pthread_once_t flag{PTHREAD_ONCE_INIT}; };
+using once_flag = struct { pthread_once_t flag = PTHREAD_ONCE_INIT; };
 
 template <class T>
 inline void call_once(once_flag& once, T func) {


### PR DESCRIPTION
This fixes a build issue in some environments where PTHREAD_ONCE_INIT is a braced value, resulting int double brace initialization.